### PR TITLE
feat: add /release end-to-end delivery command (v2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.11.0] - 2026-07-03
+
+### Added
+- **`/release` — end-to-end feature-delivery orchestrator, added across all four packages.** A thin orchestrator (it delegates, never re-implements): resolves a feature branch (arg → `git switch` to it; on `main` with no arg → creates `feat/<slug>` and carries the work over; otherwise the current branch), then runs `/ship` + `/security` + `/diff-review` under `/verify-done` discipline — reading each sibling command's real checklist so nothing is hand-waved. A hard gate splits the safe/read-only verify half from the irreversible release half (docs → version bump → commit → push → PR → merge → tag), which confirms each step. It **stops before `npm publish`** — `publish.yml` is manual `workflow_dispatch` by design. Counts: claude commands 8→9; droid/opencode/ampcode 17→18.
+
+### Fixed
+- **Doc count drift corrected while adding `/release`.** `packages/ampcode/AGENT.md` had mis-filed `live-canvas` (a skill) under its Commands table, leaving Skills at 8 rows beneath a "9 total" header; moved it to Skills so both tables reconcile at 9. README's "Commands/Skills" section still listed a standalone `/friction` bullet (collapsed into `/remember` back in 2.9.0) — removed, and the section total corrected to match "9 skills + 9 commands".
+
+---
+
 ## [2.10.0] - 2026-06-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
          ╚══════╝╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝   ╚══════╝
 ```
 
-**AI development toolkit with 11 specialized agents and 17 commands per tool**
+**AI development toolkit with 11 specialized agents and 18 commands per tool**
 
 <p align="center">
   <img src="https://img.shields.io/github/package-json/v/hamr0/liteagents?label=version&color=2a4f8c" alt="version (auto from package.json)">
@@ -45,10 +45,10 @@ liteagents
 
 ### Supported Tools
 
-- **Claude Code** - 11 subagents + 9 skills + 8 commands (+ optional live-canvas channel plugin)
-- **Opencode** - 11 agent references + 17 commands
-- **Ampcode** - 11 subagents + 17 commands
-- **Droid** - 11 agent references + 17 commands
+- **Claude Code** - 11 subagents + 9 skills + 9 commands (+ optional live-canvas channel plugin)
+- **Opencode** - 11 agent references + 18 commands
+- **Ampcode** - 11 subagents + 18 commands
+- **Droid** - 11 agent references + 18 commands
 
 **Key Difference:**
 - **Claude Code**: Full subagent system with orchestrator + skills (auto-triggering)
@@ -131,9 +131,8 @@ Results land in `.claude/friction/antigen_review.md` with projects, error patter
 
 **Manual Skills/Commands (15):**
 
-*Hot Memory Pipeline (3)* — see the [Hot Memory](#hot-memory--project-local-learning-from-your-own-sessions) section above for the full walkthrough:
+*Hot Memory Pipeline (2)* — see the [Hot Memory](#hot-memory--project-local-learning-from-your-own-sessions) section above for the full walkthrough:
 - **stash** - Snapshot session context to `.claude/stash/` before compaction, handoff, or ending complex work
-- **friction** - Analyze all JSONL sessions for frustration signals, cluster failures per project, surface antigens
 - **remember** - Consolidate stashes + friction antigens into `.claude/memory/MEMORY.md`; auto-injected via `@MEMORY.md`
 
 *Design*:
@@ -150,6 +149,7 @@ Results land in `.claude/friction/antigen_review.md` with projects, error patter
 - **diff-review** - Review a file, branch, or range; verifies findings, fixes confirmed/unambiguous ones, asks on ambiguous or downstream-affecting ones
 - **security** - Vulnerability scan; same verify→fix→ask flow as `/diff-review`
 - **ship** - Pre-deployment checklist
+- **release** - Deliver a feature end-to-end: verify → docs → merge → tag (publish stays manual)
 - **test-generate** - Generate test suites
 
 > **Claude-only plugin:** `live-canvas-channel` is a bundled Claude Code MCP channel plugin that ships under `~/.claude/plugins/live-canvas-marketplace/`. One-time `/plugin install` + a session started with `--dangerously-load-development-channels` unlocks live mode. Skill probes for the channel on each invocation and handholds setup when missing. See [`packages/claude/skills/live-canvas/README.md`](packages/claude/skills/live-canvas/README.md) for the full walkthrough.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/AGENT.md
+++ b/packages/ampcode/AGENT.md
@@ -28,6 +28,7 @@ These subagents are available when using Ampcode CLI.
 |---|---|---|---|
 | brainstorming | Refines rough ideas into fully-formed designs through collaborative questioning | /brainstorming <session-type> <topic> | false |
 | docs-builder | Create comprehensive project documentation with structured /docs hierarchy | /docs-builder | false |
+| live-canvas | Design UI variations and collect click-to-annotate feedback from the browser (batch mode only on Amp) | /live-canvas | false |
 | trace-back | Systematically traces bugs backward through call stack to identify source | /trace-back <issue-description> | false |
 | skill-creator | Guide for creating effective skills and extending Claude capabilities | /skill-creator <skill-type> <skill-description> | false |
 | debug-method | Four-phase debugging framework - investigate root cause before any fixes | /debug-method <bug-or-error-description> | false |
@@ -35,17 +36,17 @@ These subagents are available when using Ampcode CLI.
 | test-traps | Prevents testing mock behavior and production pollution with test-only methods | /test-traps <testing-scenario> | true |
 | verify-done | Requires running verification commands before making any success claims | /verify-done <work-to-verify> | true |
 
-### Commands (8 total)
+### Commands (9 total)
 
 | ID | Description | Usage |
 |---|---|---|
-| live-canvas | Design UI variations and collect click-to-annotate feedback from the browser (batch mode only on Amp) | /live-canvas |
 | optimize | Analyze and optimize performance issues | /optimize <target-area> |
 | refactor | Refactor code while maintaining behavior and tests | /refactor <code-section> |
 | remember | Consolidate stashes + friction into project memory | /remember |
 | diff-review | Comprehensive code review including quality, tests, and architecture | /diff-review |
 | security | Security vulnerability scan and analysis | /security |
 | ship | Pre-deployment verification checklist | /ship |
+| release | Deliver a feature end-to-end: verify, docs, merge, tag (publish stays manual) | /release [branch] |
 | stash | Save session context for compaction recovery or handoffs | /stash ["optional-name"] |
 | test-generate | Generate tests, run them, verify each one actually exercises the code | /test-generate <file> |
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -1,0 +1,88 @@
+---
+name: release
+description: Deliver a feature end-to-end — verify, docs, merge, tag (publish stays manual)
+usage: /release [branch]
+argument-hint: [branch — new or existing; else current]
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(npm *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(python *), Bash(go *), Bash(cargo *), Bash(make *)
+---
+End-to-end feature-delivery **orchestrator**. It does **not** re-implement
+checks — it runs your existing gates (`/ship`, `/security`, `/diff-review`)
+under `/verify-done` discipline, then performs the release actions. Two halves
+split by a hard gate: everything **before** the gate is safe and read-only;
+everything **after** rewrites history and is confirmed step by step.
+
+**A feature branch is required — `main` is only the merge target.** `$ARGUMENTS`
+names the branch to release. Omit it only if you are already on a feature
+branch. If you are on `main` with nothing named, a branch is created for you —
+but you should be releasing a deliberately-named feature branch.
+
+## Phase 0 — Preflight (resolve a feature branch — never `main`)
+- **Resolve the release branch** — whatever gets merged into `main`:
+  - `$ARGUMENTS` given → `git switch` to it (create it if it does not exist).
+  - else not on `main` → release the **current** branch.
+  - else on `main` with no arg → **create** `feat/<slug>` (named for the
+    change) and carry your working changes onto it. **Never release `main`.**
+- **Land the feature on the branch** — if the working tree still has
+  uncommitted feature changes, commit them now; the gates must review a real
+  diff, not a dirty tree.
+- `git fetch origin`; the release diff is `origin/main...HEAD` (now guaranteed
+  to be the resolved branch). If it is empty, **stop** — nothing to release.
+- Print a one-line plan: branch · commit count · files changed.
+
+## Phase 1 — VERIFY (delegate; no hand-waving)
+**First, load the real checklists.** Locate and **read** the sibling command
+definitions so you apply their exact checks, not an approximation — glob your
+installed commands/skills for `ship.md`, `security.md`, `diff-review.md`, and
+`verify-done` (a skill or command). If one cannot be found, run that check from
+its name and **flag that its full checklist was unavailable** — never pretend
+it passed.
+
+Then run each gate and capture **fresh evidence** — the exact command, its exit
+code, and the result. Per `/verify-done`: a check you did **not** actually run
+is a **FAIL**, never an assumed pass.
+- **`/ship`** — pre-deploy gate (tests, lint, build, secrets, authz, rate
+  limit, data scope, migrations, docs-sync).
+- **`/security`** — on the changed files.
+- **`/diff-review`** — on `origin/main...HEAD`.
+
+Emit a coverage table, one row per gate: `ran? ✓/✗` · evidence · verdict. If
+any row is ✗ (could not run), the run is **Blocked 🛑** — do not continue.
+
+## 🚦 Gate
+- **Any Critical** (failing tests/build, a Critical security or diff-review
+  finding) → **stop**, report, ask how to proceed. Touch no history.
+- **Warnings, or anything you cannot confidently decide** → **stop**,
+  summarize, ask.
+- **All clean** → continue to Phase 2.
+
+## Phase 2 — DOCS (only what the feature changed)
+Update as needed, matching each file's existing format; touch nothing
+unrelated. If a doc needs no change, **say so** rather than editing for its
+own sake.
+- **CHANGELOG.md** — new entry.
+- **PRD** — the feature's PRD entry / status.
+- **context / guide** — the project's context or guide doc.
+- **README.md** — only if user-facing usage changed.
+
+## Phase 3 — RELEASE (irreversible — confirm each step)
+1. **Version bump** — pick the semver level from the change (patch / minor /
+   major; ask if ambiguous) and update `package.json`.
+2. **Commit** — `release: vX.Y.Z — <summary>`, including the docs + bump.
+3. **Push** the branch.
+4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
+   review).
+5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
+   it, **stop** and ask the user to approve — never force or bypass protection.
+6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
+   cut→tag tight — one frozen step.
+
+## Stop here — publish is your call
+Do **not** publish. `publish.yml` is manual `workflow_dispatch` **by design**.
+Print the handoff:
+> Merged, branch deleted, tagged **vX.Y.Z**. To publish, run it yourself:
+> `gh workflow run publish.yml`
+> Then confirm the version is actually live (`npm view <pkg> versions`) and
+> validate the **installed** artifact, not the working tree.
+
+Final report: **Delivered ✅ (vX.Y.Z — publish pending)** or **Blocked 🛑**
+with the specific reason.

--- a/packages/claude/CLAUDE.md
+++ b/packages/claude/CLAUDE.md
@@ -36,7 +36,7 @@ These subagents are available when using Claude Code CLI. Droid can reference th
 | test-traps | Prevents testing mock behavior and production pollution with test-only methods | /test-traps <testing-scenario> | true |
 | verify-done | Requires running verification commands before making any success claims | /verify-done <work-to-verify> | true |
 
-### Commands (8 total)
+### Commands (9 total)
 
 | ID | Description | Usage |
 |---|---|---|
@@ -46,6 +46,7 @@ These subagents are available when using Claude Code CLI. Droid can reference th
 | diff-review | Comprehensive code review including quality, tests, and architecture | /diff-review |
 | security | Security vulnerability scan and analysis | /security |
 | ship | Pre-deployment verification checklist | /ship |
+| release | Deliver a feature end-to-end: verify, docs, merge, tag (publish stays manual) | /release [branch] |
 | stash | Save session context for compaction recovery or handoffs | /stash ["optional-name"] |
 | test-generate | Generate tests, run them, verify each one actually exercises the code | /test-generate <file> |
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -1,0 +1,88 @@
+---
+name: release
+description: Deliver a feature end-to-end — verify, docs, merge, tag (publish stays manual)
+usage: /release [branch]
+argument-hint: [branch — new or existing; else current]
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(yarn:*), Bash(pytest:*), Bash(python:*), Bash(go:*), Bash(cargo:*), Bash(make:*)
+---
+End-to-end feature-delivery **orchestrator**. It does **not** re-implement
+checks — it runs your existing gates (`/ship`, `/security`, `/diff-review`)
+under `/verify-done` discipline, then performs the release actions. Two halves
+split by a hard gate: everything **before** the gate is safe and read-only;
+everything **after** rewrites history and is confirmed step by step.
+
+**A feature branch is required — `main` is only the merge target.** `$ARGUMENTS`
+names the branch to release. Omit it only if you are already on a feature
+branch. If you are on `main` with nothing named, a branch is created for you —
+but you should be releasing a deliberately-named feature branch.
+
+## Phase 0 — Preflight (resolve a feature branch — never `main`)
+- **Resolve the release branch** — whatever gets merged into `main`:
+  - `$ARGUMENTS` given → `git switch` to it (create it if it does not exist).
+  - else not on `main` → release the **current** branch.
+  - else on `main` with no arg → **create** `feat/<slug>` (named for the
+    change) and carry your working changes onto it. **Never release `main`.**
+- **Land the feature on the branch** — if the working tree still has
+  uncommitted feature changes, commit them now; the gates must review a real
+  diff, not a dirty tree.
+- `git fetch origin`; the release diff is `origin/main...HEAD` (now guaranteed
+  to be the resolved branch). If it is empty, **stop** — nothing to release.
+- Print a one-line plan: branch · commit count · files changed.
+
+## Phase 1 — VERIFY (delegate; no hand-waving)
+**First, load the real checklists.** Locate and **read** the sibling command
+definitions so you apply their exact checks, not an approximation — glob your
+installed commands/skills for `ship.md`, `security.md`, `diff-review.md`, and
+`verify-done` (a skill or command). If one cannot be found, run that check from
+its name and **flag that its full checklist was unavailable** — never pretend
+it passed.
+
+Then run each gate and capture **fresh evidence** — the exact command, its exit
+code, and the result. Per `/verify-done`: a check you did **not** actually run
+is a **FAIL**, never an assumed pass.
+- **`/ship`** — pre-deploy gate (tests, lint, build, secrets, authz, rate
+  limit, data scope, migrations, docs-sync).
+- **`/security`** — on the changed files.
+- **`/diff-review`** — on `origin/main...HEAD`.
+
+Emit a coverage table, one row per gate: `ran? ✓/✗` · evidence · verdict. If
+any row is ✗ (could not run), the run is **Blocked 🛑** — do not continue.
+
+## 🚦 Gate
+- **Any Critical** (failing tests/build, a Critical security or diff-review
+  finding) → **stop**, report, ask how to proceed. Touch no history.
+- **Warnings, or anything you cannot confidently decide** → **stop**,
+  summarize, ask.
+- **All clean** → continue to Phase 2.
+
+## Phase 2 — DOCS (only what the feature changed)
+Update as needed, matching each file's existing format; touch nothing
+unrelated. If a doc needs no change, **say so** rather than editing for its
+own sake.
+- **CHANGELOG.md** — new entry.
+- **PRD** — the feature's PRD entry / status.
+- **context / guide** — the project's context or guide doc.
+- **README.md** — only if user-facing usage changed.
+
+## Phase 3 — RELEASE (irreversible — confirm each step)
+1. **Version bump** — pick the semver level from the change (patch / minor /
+   major; ask if ambiguous) and update `package.json`.
+2. **Commit** — `release: vX.Y.Z — <summary>`, including the docs + bump.
+3. **Push** the branch.
+4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
+   review).
+5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
+   it, **stop** and ask the user to approve — never force or bypass protection.
+6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
+   cut→tag tight — one frozen step.
+
+## Stop here — publish is your call
+Do **not** publish. `publish.yml` is manual `workflow_dispatch` **by design**.
+Print the handoff:
+> Merged, branch deleted, tagged **vX.Y.Z**. To publish, run it yourself:
+> `gh workflow run publish.yml`
+> Then confirm the version is actually live (`npm view <pkg> versions`) and
+> validate the **installed** artifact, not the working tree.
+
+Final report: **Delivered ✅ (vX.Y.Z — publish pending)** or **Blocked 🛑**
+with the specific reason.

--- a/packages/droid/AGENTS.md
+++ b/packages/droid/AGENTS.md
@@ -22,7 +22,7 @@ These subagents are available when using Claude Code CLI. Droid can reference th
 | system-architect | Architect | Use for system design, architecture documents, technology selection, API design, and infrastructure planning |
 | ui-designer | UX Expert | Use for UI/UX design, wireframes, prototypes, front-end specifications, and user experience optimization |
 
-## Droid Commands (17 total)
+## Droid Commands (18 total)
 
 | ID | Description | Usage | Auto |
 |---|---|---|---|
@@ -36,6 +36,7 @@ These subagents are available when using Claude Code CLI. Droid can reference th
 | trace-back | Systematically traces bugs backward through call stack to identify source | /trace-back <issue-description> | false |
 | security | Security vulnerability scan and analysis | /security | - |
 | ship | Pre-deployment verification checklist | /ship | - |
+| release | Deliver a feature end-to-end: verify, docs, merge, tag (publish stays manual) | /release [branch] | - |
 | skill-creator | Guide for creating effective skills and extending Claude capabilities | /skill-creator <skill-type> <skill-description> | false |
 | stash | Save session context for compaction recovery or handoffs | /stash ["optional-name"] | - |
 | debug-method | Four-phase debugging framework - investigate root cause before any fixes | /debug-method <bug-or-error-description> | false |

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -1,0 +1,88 @@
+---
+name: release
+description: Deliver a feature end-to-end — verify, docs, merge, tag (publish stays manual)
+usage: /release [branch]
+argument-hint: [branch — new or existing; else current]
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(npm *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(python *), Bash(go *), Bash(cargo *), Bash(make *)
+---
+End-to-end feature-delivery **orchestrator**. It does **not** re-implement
+checks — it runs your existing gates (`/ship`, `/security`, `/diff-review`)
+under `/verify-done` discipline, then performs the release actions. Two halves
+split by a hard gate: everything **before** the gate is safe and read-only;
+everything **after** rewrites history and is confirmed step by step.
+
+**A feature branch is required — `main` is only the merge target.** `$ARGUMENTS`
+names the branch to release. Omit it only if you are already on a feature
+branch. If you are on `main` with nothing named, a branch is created for you —
+but you should be releasing a deliberately-named feature branch.
+
+## Phase 0 — Preflight (resolve a feature branch — never `main`)
+- **Resolve the release branch** — whatever gets merged into `main`:
+  - `$ARGUMENTS` given → `git switch` to it (create it if it does not exist).
+  - else not on `main` → release the **current** branch.
+  - else on `main` with no arg → **create** `feat/<slug>` (named for the
+    change) and carry your working changes onto it. **Never release `main`.**
+- **Land the feature on the branch** — if the working tree still has
+  uncommitted feature changes, commit them now; the gates must review a real
+  diff, not a dirty tree.
+- `git fetch origin`; the release diff is `origin/main...HEAD` (now guaranteed
+  to be the resolved branch). If it is empty, **stop** — nothing to release.
+- Print a one-line plan: branch · commit count · files changed.
+
+## Phase 1 — VERIFY (delegate; no hand-waving)
+**First, load the real checklists.** Locate and **read** the sibling command
+definitions so you apply their exact checks, not an approximation — glob your
+installed commands/skills for `ship.md`, `security.md`, `diff-review.md`, and
+`verify-done` (a skill or command). If one cannot be found, run that check from
+its name and **flag that its full checklist was unavailable** — never pretend
+it passed.
+
+Then run each gate and capture **fresh evidence** — the exact command, its exit
+code, and the result. Per `/verify-done`: a check you did **not** actually run
+is a **FAIL**, never an assumed pass.
+- **`/ship`** — pre-deploy gate (tests, lint, build, secrets, authz, rate
+  limit, data scope, migrations, docs-sync).
+- **`/security`** — on the changed files.
+- **`/diff-review`** — on `origin/main...HEAD`.
+
+Emit a coverage table, one row per gate: `ran? ✓/✗` · evidence · verdict. If
+any row is ✗ (could not run), the run is **Blocked 🛑** — do not continue.
+
+## 🚦 Gate
+- **Any Critical** (failing tests/build, a Critical security or diff-review
+  finding) → **stop**, report, ask how to proceed. Touch no history.
+- **Warnings, or anything you cannot confidently decide** → **stop**,
+  summarize, ask.
+- **All clean** → continue to Phase 2.
+
+## Phase 2 — DOCS (only what the feature changed)
+Update as needed, matching each file's existing format; touch nothing
+unrelated. If a doc needs no change, **say so** rather than editing for its
+own sake.
+- **CHANGELOG.md** — new entry.
+- **PRD** — the feature's PRD entry / status.
+- **context / guide** — the project's context or guide doc.
+- **README.md** — only if user-facing usage changed.
+
+## Phase 3 — RELEASE (irreversible — confirm each step)
+1. **Version bump** — pick the semver level from the change (patch / minor /
+   major; ask if ambiguous) and update `package.json`.
+2. **Commit** — `release: vX.Y.Z — <summary>`, including the docs + bump.
+3. **Push** the branch.
+4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
+   review).
+5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
+   it, **stop** and ask the user to approve — never force or bypass protection.
+6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
+   cut→tag tight — one frozen step.
+
+## Stop here — publish is your call
+Do **not** publish. `publish.yml` is manual `workflow_dispatch` **by design**.
+Print the handoff:
+> Merged, branch deleted, tagged **vX.Y.Z**. To publish, run it yourself:
+> `gh workflow run publish.yml`
+> Then confirm the version is actually live (`npm view <pkg> versions`) and
+> validate the **installed** artifact, not the working tree.
+
+Final report: **Delivered ✅ (vX.Y.Z — publish pending)** or **Blocked 🛑**
+with the specific reason.

--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -22,7 +22,7 @@ These subagents are available when using Claude Code CLI. Opencode can reference
 | system-architect | Architect | Use for system design, architecture documents, technology selection, API design, and infrastructure planning |
 | ui-designer | UX Expert | Use for UI/UX design, wireframes, prototypes, front-end specifications, and user experience optimization |
 
-## Opencode Commands (17 total)
+## Opencode Commands (18 total)
 
 | ID | Description | Usage | Auto |
 |---|---|---|---|
@@ -36,6 +36,7 @@ These subagents are available when using Claude Code CLI. Opencode can reference
 | trace-back | Systematically traces bugs backward through call stack to identify source | /trace-back <issue-description> | false |
 | security | Security vulnerability scan and analysis | /security | - |
 | ship | Pre-deployment verification checklist | /ship | - |
+| release | Deliver a feature end-to-end: verify, docs, merge, tag (publish stays manual) | /release [branch] | - |
 | skill-creator | Guide for creating effective skills and extending Claude capabilities | /skill-creator <skill-type> <skill-description> | false |
 | stash | Save session context for compaction recovery or handoffs | /stash ["optional-name"] | - |
 | debug-method | Four-phase debugging framework - investigate root cause before any fixes | /debug-method <bug-or-error-description> | false |

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -1,0 +1,88 @@
+---
+name: release
+description: Deliver a feature end-to-end — verify, docs, merge, tag (publish stays manual)
+usage: /release [branch]
+argument-hint: [branch — new or existing; else current]
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash(git *), Bash(gh *), Bash(npm *), Bash(pnpm *), Bash(yarn *), Bash(pytest *), Bash(python *), Bash(go *), Bash(cargo *), Bash(make *)
+---
+End-to-end feature-delivery **orchestrator**. It does **not** re-implement
+checks — it runs your existing gates (`/ship`, `/security`, `/diff-review`)
+under `/verify-done` discipline, then performs the release actions. Two halves
+split by a hard gate: everything **before** the gate is safe and read-only;
+everything **after** rewrites history and is confirmed step by step.
+
+**A feature branch is required — `main` is only the merge target.** `$ARGUMENTS`
+names the branch to release. Omit it only if you are already on a feature
+branch. If you are on `main` with nothing named, a branch is created for you —
+but you should be releasing a deliberately-named feature branch.
+
+## Phase 0 — Preflight (resolve a feature branch — never `main`)
+- **Resolve the release branch** — whatever gets merged into `main`:
+  - `$ARGUMENTS` given → `git switch` to it (create it if it does not exist).
+  - else not on `main` → release the **current** branch.
+  - else on `main` with no arg → **create** `feat/<slug>` (named for the
+    change) and carry your working changes onto it. **Never release `main`.**
+- **Land the feature on the branch** — if the working tree still has
+  uncommitted feature changes, commit them now; the gates must review a real
+  diff, not a dirty tree.
+- `git fetch origin`; the release diff is `origin/main...HEAD` (now guaranteed
+  to be the resolved branch). If it is empty, **stop** — nothing to release.
+- Print a one-line plan: branch · commit count · files changed.
+
+## Phase 1 — VERIFY (delegate; no hand-waving)
+**First, load the real checklists.** Locate and **read** the sibling command
+definitions so you apply their exact checks, not an approximation — glob your
+installed commands/skills for `ship.md`, `security.md`, `diff-review.md`, and
+`verify-done` (a skill or command). If one cannot be found, run that check from
+its name and **flag that its full checklist was unavailable** — never pretend
+it passed.
+
+Then run each gate and capture **fresh evidence** — the exact command, its exit
+code, and the result. Per `/verify-done`: a check you did **not** actually run
+is a **FAIL**, never an assumed pass.
+- **`/ship`** — pre-deploy gate (tests, lint, build, secrets, authz, rate
+  limit, data scope, migrations, docs-sync).
+- **`/security`** — on the changed files.
+- **`/diff-review`** — on `origin/main...HEAD`.
+
+Emit a coverage table, one row per gate: `ran? ✓/✗` · evidence · verdict. If
+any row is ✗ (could not run), the run is **Blocked 🛑** — do not continue.
+
+## 🚦 Gate
+- **Any Critical** (failing tests/build, a Critical security or diff-review
+  finding) → **stop**, report, ask how to proceed. Touch no history.
+- **Warnings, or anything you cannot confidently decide** → **stop**,
+  summarize, ask.
+- **All clean** → continue to Phase 2.
+
+## Phase 2 — DOCS (only what the feature changed)
+Update as needed, matching each file's existing format; touch nothing
+unrelated. If a doc needs no change, **say so** rather than editing for its
+own sake.
+- **CHANGELOG.md** — new entry.
+- **PRD** — the feature's PRD entry / status.
+- **context / guide** — the project's context or guide doc.
+- **README.md** — only if user-facing usage changed.
+
+## Phase 3 — RELEASE (irreversible — confirm each step)
+1. **Version bump** — pick the semver level from the change (patch / minor /
+   major; ask if ambiguous) and update `package.json`.
+2. **Commit** — `release: vX.Y.Z — <summary>`, including the docs + bump.
+3. **Push** the branch.
+4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
+   review).
+5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
+   it, **stop** and ask the user to approve — never force or bypass protection.
+6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
+   cut→tag tight — one frozen step.
+
+## Stop here — publish is your call
+Do **not** publish. `publish.yml` is manual `workflow_dispatch` **by design**.
+Print the handoff:
+> Merged, branch deleted, tagged **vX.Y.Z**. To publish, run it yourself:
+> `gh workflow run publish.yml`
+> Then confirm the version is actually live (`npm view <pkg> versions`) and
+> validate the **installed** artifact, not the working tree.
+
+Final report: **Delivered ✅ (vX.Y.Z — publish pending)** or **Blocked 🛑**
+with the specific reason.

--- a/packages/opencode/opencode.jsonc
+++ b/packages/opencode/opencode.jsonc
@@ -169,6 +169,10 @@
       "template": "{file:./command/ship.md}",
       "description": "Pre-deployment verification checklist"
     },
+    "release": {
+      "template": "{file:./command/release.md}",
+      "description": "Deliver a feature end-to-end: verify, docs, merge, tag (publish stays manual)"
+    },
     "remember": {
       "template": "{file:./command/remember.md}",
       "description": "Consolidate stashes + friction into project memory"

--- a/packages/subagentic-manual.md
+++ b/packages/subagentic-manual.md
@@ -54,8 +54,8 @@ Install for your platform:
 - tdd-flow, test-traps, verify-done (auto-trigger)
 - brainstorming, debug-method, docs-builder, live-canvas, etc.
 
-**8 Commands** - Simple workflow helpers
-- optimize, refactor, remember, diff-review, security, ship, stash, test-generate
+**9 Commands** - Simple workflow helpers
+- optimize, refactor, remember, diff-review, security, ship, release, stash, test-generate
 
 **Orchestration System**
 - Automatic intent matching to 9 workflow patterns
@@ -117,17 +117,18 @@ Install for your platform:
 - `skill-creator` - Guide for creating new skills
 - `debug-method` - Four-phase debugging framework
 
-**Simple Commands (8)**
+**Simple Commands (9)**
 - `optimize` - Performance analysis
 - `refactor` - Maintain behavior while improving code
 - `remember` - Consolidate stashes + friction into project memory
 - `diff-review` - Review a file, branch, or range; verifies findings before fixing
 - `security` - Vulnerability scanning
 - `ship` - Pre-deployment checklist
+- `release` - Deliver a feature end-to-end: verify → docs → merge → tag (publish stays manual)
 - `stash` - Save session context for compaction recovery or handoffs
 - `test-generate` - Test suite generation
 
-### Droid/OpenCode: 17 Commands
+### Droid/OpenCode: 18 Commands
 
 Same functionality as skills+commands, but:
 - All invoked as commands (no auto-triggering)
@@ -137,7 +138,7 @@ Same functionality as skills+commands, but:
 
 **Command Categories**:
 - **Development & Testing (6)**: tdd-flow, test-traps, test-generate, debug-method, trace-back, verify-done
-- **Code Operations (5)**: refactor, optimize, diff-review, security, ship
+- **Code Operations (6)**: refactor, optimize, diff-review, security, ship, release
 - **Session & Memory (5)**: brainstorming, skill-creator, docs-builder, stash, remember
 - **Design (1)**: live-canvas
 

--- a/tests/installer/multi-tool-testing.test.js
+++ b/tests/installer/multi-tool-testing.test.js
@@ -14,8 +14,8 @@
  * If you add or remove a command/skill/agent/plugin, the matching assertion
  * fails (e.g. "commands: expected 8, got 7"). Bump the number in EXPECTED
  * to lock in the new, intended contents. Claude has native skills (own dir),
- * so it ships 8 commands + 9 skills; opencode/ampcode/droid fold those 9 skills
- * into commands as .md files, hence 17 (8 + 9).
+ * so it ships 9 commands + 9 skills; opencode/ampcode/droid fold those 9 skills
+ * into commands as .md files, hence 18 (9 + 9).
  *
  * Tests:
  * - Claude + Opencode simultaneous installation
@@ -45,10 +45,10 @@ const COUNT_BY = { agents: 'md', commands: 'md', skills: 'dir', plugins: 'dir' }
 
 // Expected delivered counts per tool. Update deliberately when content changes.
 const EXPECTED = {
-  claude:   { agents: 11, commands: 8, skills: 9, plugins: 1 },
-  opencode: { agents: 11, commands: 17 },
-  ampcode:  { agents: 11, commands: 17 },
-  droid:    { agents: 11, commands: 17 }
+  claude:   { agents: 11, commands: 9, skills: 9, plugins: 1 },
+  opencode: { agents: 11, commands: 18 },
+  ampcode:  { agents: 11, commands: 18 },
+  droid:    { agents: 11, commands: 18 }
 };
 
 // Test results tracker


### PR DESCRIPTION
Adds `/release` — a thin end-to-end feature-delivery orchestrator, mirrored across all four packages (claude/opencode/ampcode/droid) and the global `~/.claude/commands/`.

## What it does
Resolves a feature branch (arg → switch; on `main` with no arg → creates `feat/<slug>`; else current), then runs `/ship` + `/security` + `/diff-review` under `/verify-done` discipline — reading each sibling command's real checklist (no hand-waving). A hard gate splits the safe verify half from the irreversible release half (docs → bump → commit → push → PR → merge → tag). **Stops before `npm publish`** — `publish.yml` stays manual `workflow_dispatch`.

## Verification (this PR was produced by running `/release` on itself)
- `npm test` → 138/138 pass
- `npm run validate` → ready for publication
- `/security` + `/diff-review` → no findings (docs/prompt/test-count only)

## Also
- Catalog counts: claude 8→9, others 17→18; CHANGELOG 2.11.0.
- Fixed pre-existing doc drift: ampcode `live-canvas` mis-filed under Commands; README stale `/friction` bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)