### PR TITLE
release: v2.11.1 — document /release solo-repo admin-merge path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.11.1] - 2026-07-03
+
+### Changed
+- **`/release` merge step now documents the solo-repo path.** Its "stop and ask the user to approve" guard assumed a second reviewer exists — a dead end on a solo repo, where you cannot approve your own PR. Added: the expected path is then an owner-authorized admin-merge (`gh pr merge --admin`), run only on explicit say-so — a sanctioned owner action, not a silent bypass. Mirrored across all four packages + the global copy. Surfaced by dogfooding `/release` on its own v2.11.0 release.
+
+---
+
 ## [2.11.0] - 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -72,7 +72,9 @@ own sake.
 4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
    review).
 5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
-   it, **stop** and ask the user to approve — never force or bypass protection.
+   it, **stop** and ask — never force or silently bypass. On a **solo repo** you
+   cannot approve your own PR, so the expected path is an owner-authorized
+   admin-merge (`gh pr merge --admin`), run only on the user's explicit say-so.
 6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
    cut→tag tight — one frozen step.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -72,7 +72,9 @@ own sake.
 4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
    review).
 5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
-   it, **stop** and ask the user to approve — never force or bypass protection.
+   it, **stop** and ask — never force or silently bypass. On a **solo repo** you
+   cannot approve your own PR, so the expected path is an owner-authorized
+   admin-merge (`gh pr merge --admin`), run only on the user's explicit say-so.
 6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
    cut→tag tight — one frozen step.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -72,7 +72,9 @@ own sake.
 4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
    review).
 5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
-   it, **stop** and ask the user to approve — never force or bypass protection.
+   it, **stop** and ask — never force or silently bypass. On a **solo repo** you
+   cannot approve your own PR, so the expected path is an owner-authorized
+   admin-merge (`gh pr merge --admin`), run only on the user's explicit say-so.
 6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
    cut→tag tight — one frozen step.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -72,7 +72,9 @@ own sake.
 4. **Open PR** — `gh pr create` into `main` (main is PR-protected: 1 approving
    review).
 5. **Merge** — `gh pr merge --delete-branch`. If the review requirement blocks
-   it, **stop** and ask the user to approve — never force or bypass protection.
+   it, **stop** and ask — never force or silently bypass. On a **solo repo** you
+   cannot approve your own PR, so the expected path is an owner-authorized
+   admin-merge (`gh pr merge --admin`), run only on the user's explicit say-so.
 6. **Tag** — after the merge, `git tag vX.Y.Z` on `main` and push it. Keep
    cut→tag tight — one frozen step.
 


### PR DESCRIPTION
Doc-only clarification to the `/release` command, surfaced by dogfooding it on its own v2.11.0 release.

The merge-step guard said "stop and ask the user to approve" — a dead end on a solo repo where you can't approve your own PR. Now documents that the expected solo path is an owner-authorized `gh pr merge --admin`, run only on explicit say-so (sanctioned owner action, not a silent bypass).

Mirrored across all 4 packages + the global copy. CHANGELOG 2.11.1. Tests 138/138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)