### PR TITLE
release: v2.12.0 — friction intensity tiebreak + package-validation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.12.0] - 2026-07-07
+
+### Changed
+- **Friction cluster ranking now breaks ties by intensity.** Antigen/episode clusters were ordered by tier then recurrence, with equal-recurrence ties left to incidental feed order — so a mild reaction could outrank a far more intense one that recurred equally. Added a final tiebreak on median peak friction (a value already computed), so the more intense reaction ranks first. Ranking-only: it reorders within what recurrence already gated and never promotes across the severity × recurrence 2×2 (a loud one-off stays an episode). Applied identically across all four packages.
+
+### Fixed
+- **`validate-packages` failed 0/4 valid on every package.** `validatePackage` demanded a `<name>.md` for each selected command, but a command can legitimately ship as a helper subdirectory with no doc — `commands/friction/friction.js`, run by `/remember` after `/friction` was collapsed into it. The installer already bundles such subdirs; validation now matches that instead of requiring a resurrected `friction.md`. No user-facing command is re-added.
+
+---
+
 ## [2.11.1] - 2026-07-03
 
 ### Changed

--- a/docs/friction-README.md
+++ b/docs/friction-README.md
@@ -123,6 +123,13 @@ caught next time. So friction under-detects rather than over-writes.
    success the user is contradicting) is attached to each reaction, so an antigen carries
    both halves: what the agent did **and** what you said about it.
 
+**Cluster ranking is recurrence-first, intensity-on-ties.** Clusters are ordered by tier
+(severity × recurrence), then by how often they recurred, then — only to break a tie — by
+median peak friction, so a more intense reaction ranks above a milder one that recurred
+equally. Ranking never promotes across the 2×2: a loud one-off stays an episode, it just
+sorts ahead of quieter ones. Rarity still gates what becomes a rule; intensity only sorts
+within it.
+
 **Where the LLM lives:** lexical matching catches verbatim repetition ("wrong project" ×3)
 but cannot merge paraphrases ("nothing landed" vs "says pushed but none got it") — that's a
 semantic judgment. So the split is: **friction detects + cheaply pre-groups (precise); the

--- a/installer/package-manager.js
+++ b/installer/package-manager.js
@@ -583,7 +583,7 @@ class PackageManager {
       const selectedContent = await this.selectVariantContent(toolId, variant, availableContent);
 
       // Helper function to check if file/directory exists
-      const checkContentExists = async (category, items, dirName, addExtension = false) => {
+      const checkContentExists = async (category, items, dirName, addExtension = false, allowBundleDir = false) => {
         const categoryDir = path.join(packageDir, dirName);
 
         // If directory doesn't exist but items are expected, that's an issue
@@ -611,6 +611,15 @@ class PackageManager {
           }
 
           if (!fs.existsSync(itemPath)) {
+            // A command may ship as a bundled helper subdirectory (no .md doc),
+            // e.g. friction/friction.js run by /remember. The installer bundles
+            // such subdirs; accept them here so validation matches install.
+            if (allowBundleDir) {
+              const bundleDir = path.join(categoryDir, item);
+              if (fs.existsSync(bundleDir) && fs.statSync(bundleDir).isDirectory()) {
+                continue;
+              }
+            }
             const displayPath = addExtension ? `${item}.md` : item;
             issues.push(`${category.slice(0, -1)} '${displayPath}' not found in ${dirName}/ (required by ${variant} variant)`);
             missingFiles++;
@@ -627,7 +636,7 @@ class PackageManager {
 
       // Validate commands (use dynamic directory name)
       const commandsDirName = availableContent.commandsDir || 'commands';
-      await checkContentExists('commands', selectedContent.commands || [], commandsDirName, true);
+      await checkContentExists('commands', selectedContent.commands || [], commandsDirName, true, true);
 
       // Validate plugins (directories, like skills)
       await checkContentExists('plugins', selectedContent.plugins || [], 'plugins', false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/friction/friction.js
+++ b/packages/ampcode/commands/friction/friction.js
@@ -2179,8 +2179,14 @@ function clusterCandidates(allCandidates) {
   });
 
   // Drop the noise tier (one-off + mild); rank by recurrence then severity.
+  // Final tiebreak on median peak friction — graded intensity discriminates
+  // among clusters that tie on tier and recurrence. Ranking only: it reorders
+  // within what recurrence already gated, never promotes across the 2x2.
   const kept = out.filter(c => c.suggested_artifact !== 'drop');
-  kept.sort((a, b) => b.score - a.score || b.sessions - a.sessions);
+  kept.sort((a, b) =>
+    b.score - a.score
+    || b.sessions - a.sessions
+    || (b.median_peak || 0) - (a.median_peak || 0));
   return kept;
 }
 

--- a/packages/claude/commands/friction/friction.js
+++ b/packages/claude/commands/friction/friction.js
@@ -2179,8 +2179,14 @@ function clusterCandidates(allCandidates) {
   });
 
   // Drop the noise tier (one-off + mild); rank by recurrence then severity.
+  // Final tiebreak on median peak friction — graded intensity discriminates
+  // among clusters that tie on tier and recurrence. Ranking only: it reorders
+  // within what recurrence already gated, never promotes across the 2x2.
   const kept = out.filter(c => c.suggested_artifact !== 'drop');
-  kept.sort((a, b) => b.score - a.score || b.sessions - a.sessions);
+  kept.sort((a, b) =>
+    b.score - a.score
+    || b.sessions - a.sessions
+    || (b.median_peak || 0) - (a.median_peak || 0));
   return kept;
 }
 

--- a/packages/droid/commands/friction/friction.js
+++ b/packages/droid/commands/friction/friction.js
@@ -2179,8 +2179,14 @@ function clusterCandidates(allCandidates) {
   });
 
   // Drop the noise tier (one-off + mild); rank by recurrence then severity.
+  // Final tiebreak on median peak friction — graded intensity discriminates
+  // among clusters that tie on tier and recurrence. Ranking only: it reorders
+  // within what recurrence already gated, never promotes across the 2x2.
   const kept = out.filter(c => c.suggested_artifact !== 'drop');
-  kept.sort((a, b) => b.score - a.score || b.sessions - a.sessions);
+  kept.sort((a, b) =>
+    b.score - a.score
+    || b.sessions - a.sessions
+    || (b.median_peak || 0) - (a.median_peak || 0));
   return kept;
 }
 

--- a/packages/opencode/command/friction/friction.js
+++ b/packages/opencode/command/friction/friction.js
@@ -2179,8 +2179,14 @@ function clusterCandidates(allCandidates) {
   });
 
   // Drop the noise tier (one-off + mild); rank by recurrence then severity.
+  // Final tiebreak on median peak friction — graded intensity discriminates
+  // among clusters that tie on tier and recurrence. Ranking only: it reorders
+  // within what recurrence already gated, never promotes across the 2x2.
   const kept = out.filter(c => c.suggested_artifact !== 'drop');
-  kept.sort((a, b) => b.score - a.score || b.sessions - a.sessions);
+  kept.sort((a, b) =>
+    b.score - a.score
+    || b.sessions - a.sessions
+    || (b.median_peak || 0) - (a.median_peak || 0));
   return kept;
 }
 


### PR DESCRIPTION
## Summary
- **Friction cluster ranking breaks equal-recurrence ties by intensity.** Antigen/episode clusters were ordered by tier then recurrence; equal-recurrence ties fell to incidental feed order, so a mild reaction could outrank a far more intense one. Added a final tiebreak on median peak friction (already computed). Ranking-only — never promotes across the severity × recurrence 2×2. Applied identically across all four packages (claude, ampcode, opencode, droid).
- **Fixed `validate-packages` failing 0/4 valid on every package.** `validatePackage` demanded a `<name>.md` for each selected command, but a command can ship as a helper subdirectory with no doc — `commands/friction/friction.js`, run by `/remember` after `/friction` was collapsed into it. The installer already bundles such subdirs; validation now matches that. No user-facing command is re-added.

## Verification
- `npm test` → **138/138 pass** (exit 0)
- `npm run validate-packages` → **4/4 valid, 0 errors** (was 0/4)
- Ranking change verified by side-by-side old-vs-new run over 297 real sessions: identical cluster set, **0 artifact-kind changes**; synthetic case confirms the tiebreak orders a scrambled tie-group by intensity.
- `/security` + `/diff-review` on `origin/main...HEAD`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)