### PR TITLE
feat(remember): parallel per-stash extraction, model-agnostic mid-tier calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`/remember` extraction is parallel and model-agnostic.** Step 2's per-stash extraction
+  calls are now spawned as concurrent subagent calls instead of one at a time. Every
+  hardcoded `sonnet` mention (steps 2, 3, 4a) is replaced with "the mid-tier model" — a new
+  Guardrails note explains the intent (capable of semantic judgment, cheaper/faster than
+  your top reasoning tier; Sonnet is the Claude example, not a requirement) so the
+  instructions work unmodified across Claude/opencode/ampcode/droid regardless of which
+  models each tool has configured. Identical across all four packages.
+
+### Planned
+- Community marketplace submissions
+- Additional skills for data analysis
+- Enhanced testing capabilities
+- Performance optimizations
+
+---
+
+## [2.14.0] - 2026-07-10
+
 ### Added
 - **`/remember` bootstraps a standards-guide template.** A new `AGENT_RULES.md` (an AI
   agent collaboration/coding-standards guide) ships bundled next to `friction.js` in all
@@ -23,12 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 - **Antigen-gate PRD (§10):** deferred entry for a local classifier model as a paraphrase-blocking *proposer* between friction's shingle clustering and `/remember`'s LLM merge (LLM always disposes each shortlisted merge). Un-defer condition: offline measurement on the existing candidate corpus shows shingle-missed paraphrase merges would move at least one class across a recurrence tier.
-
-### Planned
-- Community marketplace submissions
-- Additional skills for data analysis
-- Enhanced testing capabilities
-- Performance optimizations
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+- Community marketplace submissions
+- Additional skills for data analysis
+- Enhanced testing capabilities
+- Performance optimizations
+
+---
+
+## [2.14.1] - 2026-07-10
+
 ### Changed
 - **`/remember` extraction is parallel and model-agnostic.** Step 2's per-stash extraction
   calls are now spawned as concurrent subagent calls instead of one at a time. Every
@@ -17,12 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   your top reasoning tier; Sonnet is the Claude example, not a requirement) so the
   instructions work unmodified across Claude/opencode/ampcode/droid regardless of which
   models each tool has configured. Identical across all four packages.
-
-### Planned
-- Community marketplace submissions
-- Additional skills for data analysis
-- Enhanced testing capabilities
-- Performance optimizations
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ capture    analyze + consolidate
 ```
 
 - **`/stash`** — snapshot the current session's context before compaction or handoff; nudges you to consolidate once a few stashes pile up
-- **`/remember`** — runs friction analysis automatically (mining JSONL session logs across *all* your projects for frustration signals, failed flows, and abandonment patterns, clustered into antigen candidates), then consolidates stashes + friction antigens into `.claude/remember/MEMORY.md`; auto-injected into `CLAUDE.md` via `@MEMORY.md` so every future session benefits
+- **`/remember`** — runs friction analysis automatically (mining JSONL session logs across *all* your projects for frustration signals, failed flows, and abandonment patterns, clustered into antigen candidates), then consolidates stashes + friction antigens into `.claude/remember/MEMORY.md`; auto-injected into `CLAUDE.md` via `@MEMORY.md` so every future session benefits. Per-stash extraction runs as concurrent subagent calls on a mid-tier model — no model name hardcoded, so it works with whatever your tool has configured
 
 `/remember` also bootstraps a one-time `AGENT_RULES.md` coding-standards template into `.claude/remember/` on first run (never overwritten again after that), referenced separately in `CLAUDE.md` for the assistant to consult when building something new — a static guide, not something the pipeline learns or extracts.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/remember.md
+++ b/packages/ampcode/commands/remember.md
@@ -10,6 +10,13 @@ Run friction analysis, then consolidate session stashes + friction antigens into
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
 - **Precision over recall for hot memory.** A false antigen loaded into `@MEMORY.md` steers every future session. When unsure, record as a low-confidence episode — do not promote.
+- **Mid-tier model, not hardcoded.** Steps 2/3/4a delegate to a mid-tier model — capable of
+  semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's Sonnet vs
+  Opus). Use whatever your tool designates as that balanced default; never hardcode a
+  vendor-specific model name.
+- **Batch independent subagent calls.** Step 2's per-stash extractions are independent of
+  each other — spawn them concurrently (parallel/background subagent calls in one turn)
+  where your tool supports it, instead of processing stashes one at a time.
 
 **What it does**
 
@@ -69,8 +76,8 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
    - Read processed manifest at `.amp/remember/.processed` — skip already-processed stashes
    - If no unprocessed stashes AND friction produced no new antigens, report "nothing to consolidate" and stop
 
-2. **Extract from unprocessed stashes** (use Task tool with sonnet model for each)
-   - For each unprocessed stash, call sonnet to extract:
+2. **Extract from unprocessed stashes** (spawn one subagent per stash, in parallel — see Guardrails)
+   - For each unprocessed stash, call the mid-tier model (see Guardrails) to extract:
      - **FACTS** (atomic, one-line): stable preferences, decisions, corrections, explicit "remember this"
      - **EPISODE** (3-5 bullet narrative): what was the goal, what was tried, outcome, lesson
      - **SKIP**: code details, file paths, errors, mechanical steps, LLM responses
@@ -78,7 +85,7 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
 
 3. **Merge into MEMORY.md**
    - Read existing `.amp/remember/MEMORY.md` and parse its sections (## Facts, ## Episodes, ## Antigens)
-   - **Facts section**: call sonnet with existing facts + newly extracted facts
+   - **Facts section**: call the mid-tier model with existing facts + newly extracted facts
      - Rules: new updates replace old, contradictions keep new version, duplicates dropped
      - Keep facts atomic, one line each
    - **Episodes section**: append new episode entries (append-only, timestamped, no dedup)
@@ -99,7 +106,7 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
 
    - Read `.amp/remember/friction/antigen_clusters.json`.
    - **4a. Classify target, then semantically consolidate** (the parts lexical matching can't do).
-     Call sonnet with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
+     Call the mid-tier model with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
      (NOT the logs), and have it:
      1. **Decide the target of each reaction — agent or self.** Drop *self/context*
         corrections where the user redirected themselves ("wrong project", "wrong window",

--- a/packages/claude/commands/remember.md
+++ b/packages/claude/commands/remember.md
@@ -10,6 +10,13 @@ Run friction analysis, then consolidate session stashes + friction antigens into
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
 - **Precision over recall for hot memory.** A false antigen loaded into `@MEMORY.md` steers every future session. When unsure, record as a low-confidence episode — do not promote.
+- **Mid-tier model, not hardcoded.** Steps 2/3/4a delegate to a mid-tier model — capable of
+  semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's Sonnet vs
+  Opus). Use whatever your tool designates as that balanced default; never hardcode a
+  vendor-specific model name.
+- **Batch independent subagent calls.** Step 2's per-stash extractions are independent of
+  each other — spawn them concurrently (parallel/background subagent calls in one turn)
+  where your tool supports it, instead of processing stashes one at a time.
 
 **What it does**
 
@@ -69,8 +76,8 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
    - Read processed manifest at `.claude/remember/.processed` — skip already-processed stashes
    - If no unprocessed stashes AND friction produced no new antigens, report "nothing to consolidate" and stop
 
-2. **Extract from unprocessed stashes** (use Task tool with sonnet model for each)
-   - For each unprocessed stash, call sonnet to extract:
+2. **Extract from unprocessed stashes** (spawn one subagent per stash, in parallel — see Guardrails)
+   - For each unprocessed stash, call the mid-tier model (see Guardrails) to extract:
      - **FACTS** (atomic, one-line): stable preferences, decisions, corrections, explicit "remember this"
      - **EPISODE** (3-5 bullet narrative): what was the goal, what was tried, outcome, lesson
      - **SKIP**: code details, file paths, errors, mechanical steps, LLM responses
@@ -78,7 +85,7 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
 
 3. **Merge into MEMORY.md**
    - Read existing `.claude/remember/MEMORY.md` and parse its sections (## Facts, ## Episodes, ## Antigens)
-   - **Facts section**: call sonnet with existing facts + newly extracted facts
+   - **Facts section**: call the mid-tier model with existing facts + newly extracted facts
      - Rules: new updates replace old, contradictions keep new version, duplicates dropped
      - Keep facts atomic, one line each
    - **Episodes section**: append new episode entries (append-only, timestamped, no dedup)
@@ -99,7 +106,7 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
 
    - Read `.claude/remember/friction/antigen_clusters.json`.
    - **4a. Classify target, then semantically consolidate** (the parts lexical matching can't do).
-     Call sonnet with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
+     Call the mid-tier model with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
      (NOT the logs), and have it:
      1. **Decide the target of each reaction — agent or self.** Drop *self/context*
         corrections where the user redirected themselves ("wrong project", "wrong window",

--- a/packages/droid/commands/remember.md
+++ b/packages/droid/commands/remember.md
@@ -10,6 +10,13 @@ Run friction analysis, then consolidate session stashes + friction antigens into
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
 - **Precision over recall for hot memory.** A false antigen loaded into `@MEMORY.md` steers every future session. When unsure, record as a low-confidence episode — do not promote.
+- **Mid-tier model, not hardcoded.** Steps 2/3/4a delegate to a mid-tier model — capable of
+  semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's Sonnet vs
+  Opus). Use whatever your tool designates as that balanced default; never hardcode a
+  vendor-specific model name.
+- **Batch independent subagent calls.** Step 2's per-stash extractions are independent of
+  each other — spawn them concurrently (parallel/background subagent calls in one turn)
+  where your tool supports it, instead of processing stashes one at a time.
 
 **What it does**
 
@@ -69,8 +76,8 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
    - Read processed manifest at `.factory/remember/.processed` — skip already-processed stashes
    - If no unprocessed stashes AND friction produced no new antigens, report "nothing to consolidate" and stop
 
-2. **Extract from unprocessed stashes** (use Task tool with sonnet model for each)
-   - For each unprocessed stash, call sonnet to extract:
+2. **Extract from unprocessed stashes** (spawn one subagent per stash, in parallel — see Guardrails)
+   - For each unprocessed stash, call the mid-tier model (see Guardrails) to extract:
      - **FACTS** (atomic, one-line): stable preferences, decisions, corrections, explicit "remember this"
      - **EPISODE** (3-5 bullet narrative): what was the goal, what was tried, outcome, lesson
      - **SKIP**: code details, file paths, errors, mechanical steps, LLM responses
@@ -78,7 +85,7 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
 
 3. **Merge into MEMORY.md**
    - Read existing `.factory/remember/MEMORY.md` and parse its sections (## Facts, ## Episodes, ## Antigens)
-   - **Facts section**: call sonnet with existing facts + newly extracted facts
+   - **Facts section**: call the mid-tier model with existing facts + newly extracted facts
      - Rules: new updates replace old, contradictions keep new version, duplicates dropped
      - Keep facts atomic, one line each
    - **Episodes section**: append new episode entries (append-only, timestamped, no dedup)
@@ -99,7 +106,7 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
 
    - Read `.factory/remember/friction/antigen_clusters.json`.
    - **4a. Classify target, then semantically consolidate** (the parts lexical matching can't do).
-     Call sonnet with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
+     Call the mid-tier model with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
      (NOT the logs), and have it:
      1. **Decide the target of each reaction — agent or self.** Drop *self/context*
         corrections where the user redirected themselves ("wrong project", "wrong window",

--- a/packages/opencode/command/remember.md
+++ b/packages/opencode/command/remember.md
@@ -10,6 +10,13 @@ Run friction analysis, then consolidate session stashes + friction antigens into
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
 - **Precision over recall for hot memory.** A false antigen loaded into `@MEMORY.md` steers every future session. When unsure, record as a low-confidence episode — do not promote.
+- **Mid-tier model, not hardcoded.** Steps 2/3/4a delegate to a mid-tier model — capable of
+  semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's Sonnet vs
+  Opus). Use whatever your tool designates as that balanced default; never hardcode a
+  vendor-specific model name.
+- **Batch independent subagent calls.** Step 2's per-stash extractions are independent of
+  each other — spawn them concurrently (parallel/background subagent calls in one turn)
+  where your tool supports it, instead of processing stashes one at a time.
 
 **What it does**
 
@@ -69,8 +76,8 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
    - Read processed manifest at `.opencode/remember/.processed` — skip already-processed stashes
    - If no unprocessed stashes AND friction produced no new antigens, report "nothing to consolidate" and stop
 
-2. **Extract from unprocessed stashes** (use Task tool with sonnet model for each)
-   - For each unprocessed stash, call sonnet to extract:
+2. **Extract from unprocessed stashes** (spawn one subagent per stash, in parallel — see Guardrails)
+   - For each unprocessed stash, call the mid-tier model (see Guardrails) to extract:
      - **FACTS** (atomic, one-line): stable preferences, decisions, corrections, explicit "remember this"
      - **EPISODE** (3-5 bullet narrative): what was the goal, what was tried, outcome, lesson
      - **SKIP**: code details, file paths, errors, mechanical steps, LLM responses
@@ -78,7 +85,7 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
 
 3. **Merge into MEMORY.md**
    - Read existing `.opencode/remember/MEMORY.md` and parse its sections (## Facts, ## Episodes, ## Antigens)
-   - **Facts section**: call sonnet with existing facts + newly extracted facts
+   - **Facts section**: call the mid-tier model with existing facts + newly extracted facts
      - Rules: new updates replace old, contradictions keep new version, duplicates dropped
      - Keep facts atomic, one line each
    - **Episodes section**: append new episode entries (append-only, timestamped, no dedup)
@@ -99,7 +106,7 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
 
    - Read `.opencode/remember/friction/antigen_clusters.json`.
    - **4a. Classify target, then semantically consolidate** (the parts lexical matching can't do).
-     Call sonnet with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
+     Call the mid-tier model with the cluster quotes + their `preceding`/`projects`/`sessions`/`self_suspect`
      (NOT the logs), and have it:
      1. **Decide the target of each reaction — agent or self.** Drop *self/context*
         corrections where the user redirected themselves ("wrong project", "wrong window",


### PR DESCRIPTION
## Summary
- `/remember` step 2 now spawns per-stash extraction as concurrent subagent calls instead of serializing one at a time.
- Every hardcoded `sonnet` mention (steps 2, 3, 4a) replaced with "the mid-tier model", plus a new Guardrails note explaining intent — portable across Claude/opencode/ampcode/droid regardless of configured models.
- Fixes a gap from the v2.14.0 release: CHANGELOG's `[Unreleased]` was never converted to a dated section at tag time; this PR also converts today's entry into `[2.14.1]` directly and bumps `package.json`.
- README + CHANGELOG updated to reflect both.

## Verification
- [x] `npm test` — 138/138 pass (fresh, this commit)
- [x] `npm run validate-packages` — 4/4 tools VALID, 0 missing files
- [x] Diffed all 4 packages' `remember.md` against the canonical (claude) after substituting each tool's dir/filename tokens — purely mechanical, no stray content drift
- [x] Confirmed zero leftover `sonnet` mentions anywhere in the 4 files
- [x] `~/.claude` local install re-synced from the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzrhPZduyKkZKZpN5n4GPp