### PR TITLE
chore: gitignore validate-packages build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ liteagents-*.tgz
 # Local test reports (ephemeral output from local test runs)
 TEST_REPORT.md
 test-report.json
+validation-results.json
 
 # Local browser-automation scratch (barebrowse mcp)
 .barebrowse/


### PR DESCRIPTION
## Summary
- `validation-results.json` is regenerated on every `npm run validate-packages` run and wasn't gitignored, so it kept showing up as untracked noise in `git status`.

## Test plan
- `.gitignore`-only change, no code paths affected.

https://claude.ai/code/session_01LzrhPZduyKkZKZpN5n4GPp