### PR TITLE
release: v2.15.0 — /stash mid-tier model + background dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `/stash` delegates the write-up to a mid-tier-model subagent, dispatched in the background
+  where the tool supports it, instead of writing inline on the top-tier session model —
+  drafting stays inline (only the running session has conversation context), but formatting
+  and file I/O move off the main turn. Falls back to inline writing if subagent/background
+  dispatch isn't available.
+
 ### Planned
 - Community marketplace submissions
 - Additional skills for data analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+- Community marketplace submissions
+- Additional skills for data analysis
+- Enhanced testing capabilities
+- Performance optimizations
+
+---
+
+## [2.15.0] - 2026-07-13
+
 ### Changed
 - `/stash` delegates the write-up to a mid-tier-model subagent, dispatched in the background
   where the tool supports it, instead of writing inline on the top-tier session model —
   drafting stays inline (only the running session has conversation context), but formatting
   and file I/O move off the main turn. Falls back to inline writing if subagent/background
   dispatch isn't available.
-
-### Planned
-- Community marketplace submissions
-- Additional skills for data analysis
-- Enhanced testing capabilities
-- Performance optimizations
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Liteagents ships a two-command pipeline that turns Claude Code's session logs in
 capture    analyze + consolidate
 ```
 
-- **`/stash`** — snapshot the current session's context before compaction or handoff; nudges you to consolidate once a few stashes pile up
+- **`/stash`** — snapshot the current session's context before compaction or handoff; nudges you to consolidate once a few stashes pile up. The write-up runs on a mid-tier model, dispatched as a background subagent where your tool supports it, so the session isn't blocked on formatting/file I/O
 - **`/remember`** — runs friction analysis automatically (mining JSONL session logs across *all* your projects for frustration signals, failed flows, and abandonment patterns, clustered into antigen candidates), then consolidates stashes + friction antigens into `.claude/remember/MEMORY.md`; auto-injected into `CLAUDE.md` via `@MEMORY.md` so every future session benefits. Per-stash extraction runs as concurrent subagent calls on a mid-tier model — no model name hardcoded, so it works with whatever your tool has configured
 
 `/remember` also bootstraps a one-time `AGENT_RULES.md` coding-standards template into `.claude/remember/` on first run (never overwritten again after that), referenced separately in `CLAUDE.md` for the assistant to consult when building something new — a static guide, not something the pipeline learns or extracts.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/stash.md
+++ b/packages/ampcode/commands/stash.md
@@ -10,14 +10,25 @@ Save session context for compaction recovery or handoffs.
 **Guardrails**
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
+- **Mid-tier model, not hardcoded.** The write-up subagent (step 2) uses a mid-tier model —
+  capable of semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's
+  Sonnet vs Opus). Use whatever your tool designates as that balanced default; never hardcode
+  a vendor-specific model name.
+- **Background dispatch where supported.** Run the write-up subagent in the background
+  (non-blocking) so the session isn't held up waiting on formatting/file I/O. Fall back to
+  writing inline (today's behavior) if your tool has no subagent or background-dispatch
+  mechanism.
 
 **What it does**
-1. Captures current conversation context and key decisions
-2. Records active work in progress
-3. Stores important findings and insights
-4. Creates stash file in `.amp/stash/`
-5. Enables context restoration after compaction
-6. **Consolidation nudge** — after saving, count the unprocessed backlog:
+1. Drafts a compact brief of current conversation context, key decisions, active work in
+   progress, and findings/insights — done inline, since only the running session holds full
+   conversation context
+2. Hands the brief to a subagent on the mid-tier model (see Guardrails) to expand into the
+   full stash file at `.amp/stash/<name>.md`, dispatched in the background where the tool
+   supports it. Falls back to writing inline if subagent/background dispatch isn't available
+3. Enables context restoration after compaction
+4. **Consolidation nudge** — whichever actor wrote the file (the subagent, or the session
+   itself on the inline fallback) counts the unprocessed backlog after saving:
    `unprocessed = (files in .amp/stash/*.md) − (entries in .amp/remember/.processed)`
    (a missing `.processed` manifest means 0 processed). If `unprocessed >= 5`, end with one line:
    > 📝 N stashes since last consolidation — run `/remember` to fold them into memory.
@@ -50,3 +61,5 @@ cat .amp/stash/<name>.md
 - Stashes stored in `.amp/stash/` (project-local)
 - Automatically includes: timestamp, active plan, recent decisions
 - Maximum context retention with minimal token usage
+- When dispatched in the background, the "Stashed to X" confirmation and consolidation nudge
+  arrive as the subagent's completion notification rather than inline in the same turn

--- a/packages/claude/commands/stash.md
+++ b/packages/claude/commands/stash.md
@@ -10,14 +10,25 @@ Save session context for compaction recovery or handoffs.
 **Guardrails**
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
+- **Mid-tier model, not hardcoded.** The write-up subagent (step 2) uses a mid-tier model —
+  capable of semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's
+  Sonnet vs Opus). Use whatever your tool designates as that balanced default; never hardcode
+  a vendor-specific model name.
+- **Background dispatch where supported.** Run the write-up subagent in the background
+  (non-blocking) so the session isn't held up waiting on formatting/file I/O. Fall back to
+  writing inline (today's behavior) if your tool has no subagent or background-dispatch
+  mechanism.
 
 **What it does**
-1. Captures current conversation context and key decisions
-2. Records active work in progress
-3. Stores important findings and insights
-4. Creates stash file in `.claude/stash/`
-5. Enables context restoration after compaction
-6. **Consolidation nudge** — after saving, count the unprocessed backlog:
+1. Drafts a compact brief of current conversation context, key decisions, active work in
+   progress, and findings/insights — done inline, since only the running session holds full
+   conversation context
+2. Hands the brief to a subagent on the mid-tier model (see Guardrails) to expand into the
+   full stash file at `.claude/stash/<name>.md`, dispatched in the background where the tool
+   supports it. Falls back to writing inline if subagent/background dispatch isn't available
+3. Enables context restoration after compaction
+4. **Consolidation nudge** — whichever actor wrote the file (the subagent, or the session
+   itself on the inline fallback) counts the unprocessed backlog after saving:
    `unprocessed = (files in .claude/stash/*.md) − (entries in .claude/remember/.processed)`
    (a missing `.processed` manifest means 0 processed). If `unprocessed >= 5`, end with one line:
    > 📝 N stashes since last consolidation — run `/remember` to fold them into memory.
@@ -50,3 +61,5 @@ cat .claude/stash/<name>.md
 - Stashes stored in `.claude/stash/` (project-local)
 - Automatically includes: timestamp, active plan, recent decisions
 - Maximum context retention with minimal token usage
+- When dispatched in the background, the "Stashed to X" confirmation and consolidation nudge
+  arrive as the subagent's completion notification rather than inline in the same turn

--- a/packages/droid/commands/stash.md
+++ b/packages/droid/commands/stash.md
@@ -10,14 +10,25 @@ Save session context for compaction recovery or handoffs.
 **Guardrails**
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
+- **Mid-tier model, not hardcoded.** The write-up subagent (step 2) uses a mid-tier model —
+  capable of semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's
+  Sonnet vs Opus). Use whatever your tool designates as that balanced default; never hardcode
+  a vendor-specific model name.
+- **Background dispatch where supported.** Run the write-up subagent in the background
+  (non-blocking) so the session isn't held up waiting on formatting/file I/O. Fall back to
+  writing inline (today's behavior) if your tool has no subagent or background-dispatch
+  mechanism.
 
 **What it does**
-1. Captures current conversation context and key decisions
-2. Records active work in progress
-3. Stores important findings and insights
-4. Creates stash file in `.factory/stash/`
-5. Enables context restoration after compaction
-6. **Consolidation nudge** — after saving, count the unprocessed backlog:
+1. Drafts a compact brief of current conversation context, key decisions, active work in
+   progress, and findings/insights — done inline, since only the running session holds full
+   conversation context
+2. Hands the brief to a subagent on the mid-tier model (see Guardrails) to expand into the
+   full stash file at `.factory/stash/<name>.md`, dispatched in the background where the tool
+   supports it. Falls back to writing inline if subagent/background dispatch isn't available
+3. Enables context restoration after compaction
+4. **Consolidation nudge** — whichever actor wrote the file (the subagent, or the session
+   itself on the inline fallback) counts the unprocessed backlog after saving:
    `unprocessed = (files in .factory/stash/*.md) − (entries in .factory/remember/.processed)`
    (a missing `.processed` manifest means 0 processed). If `unprocessed >= 5`, end with one line:
    > 📝 N stashes since last consolidation — run `/remember` to fold them into memory.
@@ -50,3 +61,5 @@ cat .factory/stash/<name>.md
 - Stashes stored in `.factory/stash/` (project-local)
 - Automatically includes: timestamp, active plan, recent decisions
 - Maximum context retention with minimal token usage
+- When dispatched in the background, the "Stashed to X" confirmation and consolidation nudge
+  arrive as the subagent's completion notification rather than inline in the same turn

--- a/packages/opencode/command/stash.md
+++ b/packages/opencode/command/stash.md
@@ -10,14 +10,25 @@ Save session context for compaction recovery or handoffs.
 **Guardrails**
 - Favor straightforward, minimal implementations first and add complexity only when requested or clearly required.
 - Keep changes tightly scoped to the requested outcome.
+- **Mid-tier model, not hardcoded.** The write-up subagent (step 2) uses a mid-tier model —
+  capable of semantic judgment, cheaper/faster than your top reasoning tier (e.g. Claude's
+  Sonnet vs Opus). Use whatever your tool designates as that balanced default; never hardcode
+  a vendor-specific model name.
+- **Background dispatch where supported.** Run the write-up subagent in the background
+  (non-blocking) so the session isn't held up waiting on formatting/file I/O. Fall back to
+  writing inline (today's behavior) if your tool has no subagent or background-dispatch
+  mechanism.
 
 **What it does**
-1. Captures current conversation context and key decisions
-2. Records active work in progress
-3. Stores important findings and insights
-4. Creates stash file in `.opencode/stash/`
-5. Enables context restoration after compaction
-6. **Consolidation nudge** — after saving, count the unprocessed backlog:
+1. Drafts a compact brief of current conversation context, key decisions, active work in
+   progress, and findings/insights — done inline, since only the running session holds full
+   conversation context
+2. Hands the brief to a subagent on the mid-tier model (see Guardrails) to expand into the
+   full stash file at `.opencode/stash/<name>.md`, dispatched in the background where the tool
+   supports it. Falls back to writing inline if subagent/background dispatch isn't available
+3. Enables context restoration after compaction
+4. **Consolidation nudge** — whichever actor wrote the file (the subagent, or the session
+   itself on the inline fallback) counts the unprocessed backlog after saving:
    `unprocessed = (files in .opencode/stash/*.md) − (entries in .opencode/remember/.processed)`
    (a missing `.processed` manifest means 0 processed). If `unprocessed >= 5`, end with one line:
    > 📝 N stashes since last consolidation — run `/remember` to fold them into memory.
@@ -50,3 +61,5 @@ cat .opencode/stash/<name>.md
 - Stashes stored in `.opencode/stash/` (project-local)
 - Automatically includes: timestamp, active plan, recent decisions
 - Maximum context retention with minimal token usage
+- When dispatched in the background, the "Stashed to X" confirmation and consolidation nudge
+  arrive as the subagent's completion notification rather than inline in the same turn

--- a/packages/subagentic-manual.md
+++ b/packages/subagentic-manual.md
@@ -156,7 +156,10 @@ and wiring the memory into your agent config file.
 ```
 
 1. **`/stash`** - Snapshot current session context to the tool's `…/stash/`. Use before
-   compaction, handoffs, or ending complex work. After saving it counts the unprocessed backlog
+   compaction, handoffs, or ending complex work. The session drafts the raw content inline
+   (only it holds conversation context), then a mid-tier-model subagent expands and writes the
+   file — dispatched in the background where the tool supports it, falling back to writing
+   inline otherwise. Whichever actor wrote the file counts the unprocessed backlog
    (`stash files − .processed entries`) and, at 5+, nudges you to run `/remember`. No counter is
    stored; running `/remember` clears the backlog.
 2. **`/remember`** - Runs friction analysis first (best-effort — scores sessions across *all* your


### PR DESCRIPTION
## Summary
- `/stash` now drafts session context inline (only the running session has conversation context), then hands off to a mid-tier-model subagent to expand and write the formatted stash file — dispatched in the background where the tool supports it, falling back to inline writing otherwise.
- Applied identically across all 4 packages (claude/opencode/ampcode/droid), byte-for-byte parity verified modulo path prefix.
- Docs synced: README, `subagentic-manual.md`, CHANGELOG (dated `[2.15.0]`).
- Version bumped 2.14.1 → 2.15.0 (minor — backward-compatible feature addition).

## Test plan
- [x] `npm test` — 138/138 passed
- [x] `npm run validate-packages` — 4/4 packages VALID, 0 missing files
- [x] Diff-reviewed: fixed an actor-ambiguity gap in the consolidation-nudge step and a docs-sync gap (README/subagentic-manual) before this PR
- [x] Secrets/debug-leftover scan on the diff — clean

https://claude.ai/code/session_01LzrhPZduyKkZKZpN5n4GPp