### PR TITLE
chore(release): 2.15.3 — resolve live-canvas-channel plugin advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced testing capabilities
 - Performance optimizations
 
+## [2.15.3] - 2026-08-04
+
+### Security
+- Merges Dependabot #29/#28: hono 4.13.0 (closes residual moderate ReDoS,
+  GHSA-8j4g-w8fx-2239), ip-address 10.4.0 (3 high SSRF/trust-boundary
+  advisories). Also applies `npm audit fix` for fast-uri 3.1.5 (high,
+  GHSA-7p8r-x3mc-p8w7) — flagged by audit but not yet proposed as a
+  separate Dependabot PR. Transitive deps of the bundled live-canvas-channel
+  plugin's MCP SDK; unreachable in its stdio server. Plugin audit: 3 → 0
+  vulnerabilities. 138 root tests green.
+
 ## [2.15.2] - 2026-07-24
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "AI development toolkit with 11 specialized agents and 17 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/claude/plugins/live-canvas-marketplace/plugins/live-canvas-channel/package-lock.json
+++ b/packages/claude/plugins/live-canvas-marketplace/plugins/live-canvas-channel/package-lock.json
@@ -448,9 +448,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Merges Dependabot #29 (hono 4.13.0, closes residual moderate ReDoS GHSA-8j4g-w8fx-2239) and #28 (ip-address 10.4.0, closes 3 high SSRF/trust-boundary advisories) — both already merged directly.
- Applies `npm audit fix` for fast-uri 3.1.5 (high, GHSA-7p8r-x3mc-p8w7) — supersedes Dependabot #30, which proposes the identical lockfile change.
- Plugin (`packages/claude/plugins/live-canvas-marketplace/plugins/live-canvas-channel`) audit: 3 → 0 vulnerabilities.
- Version bumped 2.15.2 → 2.15.3 (patch — dependency security fix only).

## Test plan
- [x] `npm audit` on the plugin's isolated lockfile — 0 vulnerabilities
- [x] `npm test` — 138/138 passed
- [x] `npm run validate-packages` — 4/4 packages VALID

https://claude.ai/code/session_01LzrhPZduyKkZKZpN5n4GPp