### PR TITLE
release: v2.17.1 — the dead TOC anchor in three kits' AGENT_RULES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced testing capabilities
 - Performance optimizations
 
+## [2.17.1] - 2026-08-25
+
+### Fixed
+- **`AGENT_RULES.md`'s table of contents linked to an anchor that does not exist** in the
+  droid, opencode and ampcode kits. Entry 9 pointed at `#claudemd-stub` while the heading it
+  names is `## AGENTS.md Stub` / `## AGENT.md Stub` — anchors `#agentsmd-stub` /
+  `#agentmd-stub`. The per-tool rename substituted the visible heading text and the link
+  label and left the anchor on the claude spelling, so the link was dead in three of four
+  kits. Claude's was correct and is untouched. Cosmetic, but it is the mention-form this repo
+  already has a rule about: a rename sweep must cover every form, and an anchor is one. Every
+  TOC anchor in all four copies was audited against every heading; this was the only
+  mismatch. Found while diffing the agentic-toolkit mirror, which carried the correct anchor
+  and the *wrong* settings path — each side right about a different line.
+
 ## [2.17.0] - 2026-08-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "AI development toolkit with 11 specialized agents and 18 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Patch release. One-line fix per kit, already on `main` as `99ade23`; this adds the CHANGELOG entry and the version bump.

`AGENT_RULES.md`'s TOC entry 9 linked `#claudemd-stub` in the droid, opencode and ampcode kits, while the heading it names is `## AGENTS.md Stub` / `## AGENT.md Stub` — anchors `#agentsmd-stub` / `#agentmd-stub`. The per-tool rename substituted the visible heading text and the link label and left the anchor on the claude spelling, so the link was dead in three of four kits. Claude's was correct and is untouched.

Cosmetic, but it's the mention-form this repo already has a rule about: a rename sweep must cover every form, and an anchor is one. Every TOC anchor in all four copies was audited against every heading — this was the only mismatch, and it's the only change.

Found while diffing the agentic-toolkit mirror, which carried the correct anchor and the *wrong* settings path — each side right about a different line.

**Verified:** 856/856 passing, exit 0; `npm run validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)