### PR TITLE
release: v2.19.0 — H2 line ranges in docs/index.md, /remember auto re-index, AGENT_RULES pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced testing capabilities
 - Performance optimizations
 
+## [2.19.0] - 2026-08-26
+
+### Changed
+- **`docs/index.md` rows now list each doc's H2 headings, one per line, with a line range.**
+  The index is meant to let an agent find and slice-read a section without opening the doc —
+  previously each row carried only an H1, a line count, and a link, so an agent still had to
+  open the file to find anything inside it. Each H2 line reuses the exact `headings()` +
+  `fenceMask()` boundaries `scan` already writes to `outline.json` (no second parser), so a
+  heading inside a fenced code block still never appears. Archive rows stay H1-only — an
+  archived doc is frozen history, not a live section to route into.
+- **`/remember` step 7 self-heals `docs/index.md` every run, not just at reorg time.** Any
+  drift `due` reports (new/moved/changed/deleted, not only the >=5-doc DUE threshold) now
+  also re-runs `index-flat` — script-only, no model call — so the index stays current between
+  full `/docs-builder reorg` passes instead of silently drifting until the next one.
+- **`AGENT_RULES.md` demoted from an `@`-include to a plain path pointer.** It was wired into
+  CLAUDE.md as `@.claude/remember/AGENT_RULES.md`, which hot-loads the whole file into every
+  session even though it's documented as "not hot context" — measured at ~6.5k tokens/session
+  of standards prose loaded despite the file's own claim otherwise. `MEMORY.md` stays
+  `@`-referenced (it is hot); `AGENT_RULES.md` is now a plain path line, read only when
+  designing or building something new.
+
 ## [2.18.0] - 2026-08-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,5 +30,5 @@ For full standards (testing, twelve-factor, deployment), see `.claude/remember/A
 <!-- AGENT_RULES:START -->
 Consult when building something new or adding a feature — a standards guide, not hot
 context like MEMORY.md above:
-@.claude/remember/AGENT_RULES.md
+.claude/remember/AGENT_RULES.md
 <!-- AGENT_RULES:END -->

--- a/docs/product/remember-README.md
+++ b/docs/product/remember-README.md
@@ -45,8 +45,8 @@ your repo.
   moments you had to correct the agent), then consolidates stashes + friction antigens into
   `MEMORY.md` and wires up `@MEMORY.md`. On first run only, it also bootstraps a bundled
   `AGENT_RULES.md` standards template into `.claude/remember/` and wires up a second,
-  independent `@`-reference — a guide to consult when building something new, not hot
-  context (see §2).
+  independent section using a plain path pointer, not an `@`-reference — a guide to consult
+  when building something new, not hot context (see §2).
 
 The two sources complement each other by **source and trust**: stashes are what *you
 deliberately wrote down*; friction is what the agent *did wrong that you reacted to*,
@@ -229,9 +229,14 @@ quote.
 - **Bootstraps `AGENT_RULES.md` once.** If `.claude/remember/AGENT_RULES.md` doesn't exist,
   it's copied from the bundled template next to `friction.cjs`; if it already exists, it's
   left alone — user-owned from that point on. When present, `/remember` injects a second,
-  independent `<!-- AGENT_RULES:START -->…<!-- AGENT_RULES:END -->` section into CLAUDE.md
-  (`@.claude/remember/AGENT_RULES.md`), framed as a standards guide for new-feature work —
-  not hot context loaded every session like MEMORY.md.
+  independent `<!-- AGENT_RULES:START -->…<!-- AGENT_RULES:END -->` section into CLAUDE.md as
+  a plain path pointer (not `@`-referenced — it's a standards guide read when designing
+  something new, not hot context loaded every session like MEMORY.md).
+- **Step 7: docs reconcile check.** Best-effort, crash-isolated: runs `docs-builder.cjs due`
+  against `docs/.docs-builder/ledger.json`, and on ANY drift it prints (new/moved/changed/
+  deleted, not just crossing the >=5-doc DUE threshold) it also re-runs `index-flat` right
+  there — script-only, no model call — so `docs/index.md` self-heals every `/remember` run
+  instead of waiting for the next full `/docs-builder reorg`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "AI development toolkit with 11 specialized agents and 18 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/docs-builder.md
+++ b/packages/ampcode/commands/docs-builder.md
@@ -747,7 +747,13 @@ Writes **one** `docs/index.md` covering the whole corpus, in three sections: `##
 (one row per file under `docs/product/`, plus any pages under `PAGES` — default `docs/wiki/`
 — if they exist, plus any doc still sitting in place elsewhere), `## Logs` (one row per file
 under `docs/logs/`), and `## Archive` (one row per file under `docs/archive/`). Each row is
-an H1 title, a line count, and a link. No theme grouping, no `labels.json`, no model call.
+an H1 title, a line count, and a link, plus one indented line per H2 heading (in document
+order) so an agent can find and slice-read a section without opening the doc — each H2
+line carries its own `(Lstart–end)` line range, reusing the SAME `headings()`+`fenceMask()`
+boundaries `scan` already writes to `outline.json` (no second parser). Omitted when the doc
+has no H2s. `## Archive` rows are H1-only, never H2 lines — an archived doc is frozen
+history, not a live section to route into. No theme grouping, no `labels.json`, no model
+call.
 Default destination `docs/index.md` — **the only writer of that default path** in this whole
 pipeline (nothing else writes an index at all).
 `search` reads `outline.json`, never `index.md`. Prints the row counts and records a `log.md`

--- a/packages/ampcode/commands/docs-builder/docs-builder.cjs
+++ b/packages/ampcode/commands/docs-builder/docs-builder.cjs
@@ -728,14 +728,33 @@ function plan(outlineF, labelsF) {
 // tripwire, never a prune, never a collapse, never a delete.
 const ARCHIVE_WARN_ROWS = 100; // stated default, not measured — see docs-builder-v3-spec.md
 
-function indexRow(rel, dest) {
+// `includeH2` is false for archive rows: an archived doc is frozen history, not a live
+// section a reader is being routed into, so its row stays H1 + line count + link only.
+function indexRow(rel, dest, includeH2) {
   const text = read(rel);
-  const h1 = (text.split('\n').find(l => l.startsWith('# ')) || '').slice(2).trim();
-  const lines = text.split('\n').length;
+  const lines = text.split('\n');
+  // Same headings()+fenceMask() path scan() uses -- no second parser -- so an H2 inside a
+  // ``` fence is masked out here exactly as it is there.
+  const mask = fenceMask(lines);
+  const { h1, heads } = headings(lines, mask);
   // Read from INSIDE index.md, so the link must resolve relative to index.md's own
   // directory, not the repo root.
   const relLink = path.relative(path.dirname(dest), repoPath(rel)).split(path.sep).join('/');
-  return `- [${h1 || path.basename(rel)}](${relLink}) — ${lines} lines\n`;
+  let row = `- [${h1 || path.basename(rel)}](${relLink}) — ${lines.length} lines\n`;
+  if (!includeH2) return row;
+  // One line per H2, each with its own line range: from the `## ` heading's own 1-based
+  // line through the line before the next heading of level <= 2 (H1 or H2), or EOF for the
+  // last one -- the SAME boundary scan() uses to write s/e into outline.json, re-derived
+  // here from the same heads array rather than duplicated as a second computation. Lets an
+  // agent jump straight to (and slice-read) a section without opening the doc at all.
+  const boundaries = heads.filter(h => h.lvl <= 2);
+  boundaries.forEach((h, i) => {
+    if (h.lvl !== 2) return;
+    const start = h.line;
+    const end = i + 1 < boundaries.length ? boundaries[i + 1].line - 1 : lines.length;
+    row += `  - ${h.text} (L${start}–${end})\n`;
+  });
+  return row;
 }
 
 function renderSection(title, rows) {
@@ -767,9 +786,10 @@ function indexFlat() {
   const outRel = process.env.OUT || 'docs/index.md';
   const dest = repoPath(outRel);
   const productRows = [...productFiles, ...pageFiles].sort()
-    .map(f => ({ file: f, row: indexRow(f, dest) }));
-  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
-  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
+    .map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  // Archive rows are deliberately H1-only -- frozen history, not a live section to route into.
+  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, false) }));
 
   let s = '# Index\n\n';
   // Unconditional — not gated on row count, unlike ARCHIVE_WARN_ROWS below: a reader should

--- a/packages/ampcode/commands/remember.md
+++ b/packages/ampcode/commands/remember.md
@@ -346,12 +346,13 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      inline duplication is needed
    - If `.amp/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers:
+     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
+     — an `@`-reference hot-loads the whole file into every session, and this is a standards
+     guide to consult when designing/building something new, not hot context:
      ```
      <!-- AGENT_RULES:START -->
-     Consult when building something new or adding a feature — a standards guide, not hot
-     context like MEMORY.md above:
-     @.amp/remember/AGENT_RULES.md
+     Standards guide (read when designing/building something new, not hot context):
+     .amp/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENT.md already has a given pair, replace the
@@ -411,11 +412,12 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
 6. **Update processed manifest**
    - Append paths of newly processed stashes to `.amp/remember/.processed`
 
-7. **Docs reconcile check — DETECT ONLY** (best-effort, crash-isolated like step 0)
+7. **Docs reconcile check + auto re-index** (best-effort, crash-isolated like step 0)
 
-   `/remember` never reconciles docs, never writes frontmatter, never edits a page. It
-   prints at most one nudge line. Wrapped so any failure here can never block the memory
-   write that already happened in steps 3-6.
+   `/remember` never reconciles doc CONTENT, never writes frontmatter, never edits a page —
+   the only write here is the generated `docs/index.md` itself, via the same deterministic
+   `index-flat` script `/docs-builder` already uses, never a model call. Wrapped so any
+   failure here can never block the memory write that already happened in steps 3-6.
 
    - **Locate `docs-builder.cjs`** — bundled next to this command at
      `docs-builder/docs-builder.cjs` (same convention as `remember/friction.cjs`). Call it by
@@ -444,7 +446,19 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
    - If `due` prints "no ledger yet" (no `docs/.docs-builder/ledger.json` to compare against),
      do NOT relay it — print the same `/docs-builder reorg` line as the no-`docs/.docs-builder/`
      case above, for the same reason: `ledger` would stamp an unsorted pile as correct.
-   - If DUE, end with one line and nothing more:
+   - **Auto re-index — script only, no model, in addition to the DUE advisory below, not a
+     replacement for it.** If `due`'s output was NOT `docs unchanged since <sha>. NOT due.`
+     (i.e. it printed a row table -- any new/moved/moved+changed/changed/deleted doc, whether
+     or not the >=5 threshold below was crossed), the index has drifted and self-heals right
+     here, unconditionally:
+     ```bash
+     node <docs-builder.cjs> index-flat
+     ```
+     Same script `/docs-builder reorg` already calls, run standalone — no model call, no
+     interview, nothing moves. Note in the step-8 report that `docs/index.md` (and
+     `docs/log.md`, if `index-flat` touched it) were regenerated, so they are included
+     alongside whatever step 3-6 already changed when this run is committed.
+   - If DUE (the row count crossed the >=5 threshold), ALSO end with one line:
      ```
      docs: 7 changed since 991f72d3 — run /docs-builder reorg
      ```
@@ -489,12 +503,14 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      ledger: ag-002 "literal scoped ask"         ESCALATED → Fact; 2 phrasings failed. Hook or accept?
      ```
    - If AGENT_RULES.md was bootstrapped this run, say so (one line)
+   - If step 7 ran the auto re-index, say so and name the regenerated files
+     (`docs/index.md`, plus `docs/log.md` if touched) so they are staged with this run
    - Confirm MEMORY.md and AGENT.md updated
 
 **File locations (all project-local — two dirs: `/stash` owns `.amp/stash/`, `/remember` owns `.amp/remember/`)**
 - Stash files: `.amp/stash/*.md`
 - Memory file: `.amp/remember/MEMORY.md` (single source of truth, referenced as `@.amp/remember/MEMORY.md`)
-- Rules template: `.amp/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced as `@.amp/remember/AGENT_RULES.md`)
+- Rules template: `.amp/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced by a plain path pointer, not `@`-referenced — see step 5)
 - Antigen ledger: `.amp/remember/ledger.json` (per-rule evidence trail: class, status, attempts/rejected-buffer, recurrence-while-hot)
 - Consolidation report: `.amp/remember/report.md` (latest step-8 report, overwritten each run)
 - Processed manifest: `.amp/remember/.processed`

--- a/packages/claude/commands/docs-builder.md
+++ b/packages/claude/commands/docs-builder.md
@@ -747,7 +747,13 @@ Writes **one** `docs/index.md` covering the whole corpus, in three sections: `##
 (one row per file under `docs/product/`, plus any pages under `PAGES` — default `docs/wiki/`
 — if they exist, plus any doc still sitting in place elsewhere), `## Logs` (one row per file
 under `docs/logs/`), and `## Archive` (one row per file under `docs/archive/`). Each row is
-an H1 title, a line count, and a link. No theme grouping, no `labels.json`, no model call.
+an H1 title, a line count, and a link, plus one indented line per H2 heading (in document
+order) so an agent can find and slice-read a section without opening the doc — each H2
+line carries its own `(Lstart–end)` line range, reusing the SAME `headings()`+`fenceMask()`
+boundaries `scan` already writes to `outline.json` (no second parser). Omitted when the doc
+has no H2s. `## Archive` rows are H1-only, never H2 lines — an archived doc is frozen
+history, not a live section to route into. No theme grouping, no `labels.json`, no model
+call.
 Default destination `docs/index.md` — **the only writer of that default path** in this whole
 pipeline (nothing else writes an index at all).
 `search` reads `outline.json`, never `index.md`. Prints the row counts and records a `log.md`

--- a/packages/claude/commands/docs-builder/docs-builder.cjs
+++ b/packages/claude/commands/docs-builder/docs-builder.cjs
@@ -728,14 +728,33 @@ function plan(outlineF, labelsF) {
 // tripwire, never a prune, never a collapse, never a delete.
 const ARCHIVE_WARN_ROWS = 100; // stated default, not measured — see docs-builder-v3-spec.md
 
-function indexRow(rel, dest) {
+// `includeH2` is false for archive rows: an archived doc is frozen history, not a live
+// section a reader is being routed into, so its row stays H1 + line count + link only.
+function indexRow(rel, dest, includeH2) {
   const text = read(rel);
-  const h1 = (text.split('\n').find(l => l.startsWith('# ')) || '').slice(2).trim();
-  const lines = text.split('\n').length;
+  const lines = text.split('\n');
+  // Same headings()+fenceMask() path scan() uses -- no second parser -- so an H2 inside a
+  // ``` fence is masked out here exactly as it is there.
+  const mask = fenceMask(lines);
+  const { h1, heads } = headings(lines, mask);
   // Read from INSIDE index.md, so the link must resolve relative to index.md's own
   // directory, not the repo root.
   const relLink = path.relative(path.dirname(dest), repoPath(rel)).split(path.sep).join('/');
-  return `- [${h1 || path.basename(rel)}](${relLink}) — ${lines} lines\n`;
+  let row = `- [${h1 || path.basename(rel)}](${relLink}) — ${lines.length} lines\n`;
+  if (!includeH2) return row;
+  // One line per H2, each with its own line range: from the `## ` heading's own 1-based
+  // line through the line before the next heading of level <= 2 (H1 or H2), or EOF for the
+  // last one -- the SAME boundary scan() uses to write s/e into outline.json, re-derived
+  // here from the same heads array rather than duplicated as a second computation. Lets an
+  // agent jump straight to (and slice-read) a section without opening the doc at all.
+  const boundaries = heads.filter(h => h.lvl <= 2);
+  boundaries.forEach((h, i) => {
+    if (h.lvl !== 2) return;
+    const start = h.line;
+    const end = i + 1 < boundaries.length ? boundaries[i + 1].line - 1 : lines.length;
+    row += `  - ${h.text} (L${start}–${end})\n`;
+  });
+  return row;
 }
 
 function renderSection(title, rows) {
@@ -767,9 +786,10 @@ function indexFlat() {
   const outRel = process.env.OUT || 'docs/index.md';
   const dest = repoPath(outRel);
   const productRows = [...productFiles, ...pageFiles].sort()
-    .map(f => ({ file: f, row: indexRow(f, dest) }));
-  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
-  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
+    .map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  // Archive rows are deliberately H1-only -- frozen history, not a live section to route into.
+  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, false) }));
 
   let s = '# Index\n\n';
   // Unconditional — not gated on row count, unlike ARCHIVE_WARN_ROWS below: a reader should

--- a/packages/claude/commands/remember.md
+++ b/packages/claude/commands/remember.md
@@ -346,12 +346,13 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      inline duplication is needed
    - If `.claude/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers:
+     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
+     — an `@`-reference hot-loads the whole file into every session, and this is a standards
+     guide to consult when designing/building something new, not hot context:
      ```
      <!-- AGENT_RULES:START -->
-     Consult when building something new or adding a feature — a standards guide, not hot
-     context like MEMORY.md above:
-     @.claude/remember/AGENT_RULES.md
+     Standards guide (read when designing/building something new, not hot context):
+     .claude/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if CLAUDE.md already has a given pair, replace the
@@ -411,11 +412,12 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
 6. **Update processed manifest**
    - Append paths of newly processed stashes to `.claude/remember/.processed`
 
-7. **Docs reconcile check — DETECT ONLY** (best-effort, crash-isolated like step 0)
+7. **Docs reconcile check + auto re-index** (best-effort, crash-isolated like step 0)
 
-   `/remember` never reconciles docs, never writes frontmatter, never edits a page. It
-   prints at most one nudge line. Wrapped so any failure here can never block the memory
-   write that already happened in steps 3-6.
+   `/remember` never reconciles doc CONTENT, never writes frontmatter, never edits a page —
+   the only write here is the generated `docs/index.md` itself, via the same deterministic
+   `index-flat` script `/docs-builder` already uses, never a model call. Wrapped so any
+   failure here can never block the memory write that already happened in steps 3-6.
 
    - **Locate `docs-builder.cjs`** — bundled next to this command at
      `docs-builder/docs-builder.cjs` (same convention as `remember/friction.cjs`). Call it by
@@ -444,7 +446,19 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
    - If `due` prints "no ledger yet" (no `docs/.docs-builder/ledger.json` to compare against),
      do NOT relay it — print the same `/docs-builder reorg` line as the no-`docs/.docs-builder/`
      case above, for the same reason: `ledger` would stamp an unsorted pile as correct.
-   - If DUE, end with one line and nothing more:
+   - **Auto re-index — script only, no model, in addition to the DUE advisory below, not a
+     replacement for it.** If `due`'s output was NOT `docs unchanged since <sha>. NOT due.`
+     (i.e. it printed a row table -- any new/moved/moved+changed/changed/deleted doc, whether
+     or not the >=5 threshold below was crossed), the index has drifted and self-heals right
+     here, unconditionally:
+     ```bash
+     node <docs-builder.cjs> index-flat
+     ```
+     Same script `/docs-builder reorg` already calls, run standalone — no model call, no
+     interview, nothing moves. Note in the step-8 report that `docs/index.md` (and
+     `docs/log.md`, if `index-flat` touched it) were regenerated, so they are included
+     alongside whatever step 3-6 already changed when this run is committed.
+   - If DUE (the row count crossed the >=5 threshold), ALSO end with one line:
      ```
      docs: 7 changed since 991f72d3 — run /docs-builder reorg
      ```
@@ -489,12 +503,14 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      ledger: ag-002 "literal scoped ask"         ESCALATED → Fact; 2 phrasings failed. Hook or accept?
      ```
    - If AGENT_RULES.md was bootstrapped this run, say so (one line)
+   - If step 7 ran the auto re-index, say so and name the regenerated files
+     (`docs/index.md`, plus `docs/log.md` if touched) so they are staged with this run
    - Confirm MEMORY.md and CLAUDE.md updated
 
 **File locations (all project-local — two dirs: `/stash` owns `.claude/stash/`, `/remember` owns `.claude/remember/`)**
 - Stash files: `.claude/stash/*.md`
 - Memory file: `.claude/remember/MEMORY.md` (single source of truth, referenced as `@.claude/remember/MEMORY.md`)
-- Rules template: `.claude/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced as `@.claude/remember/AGENT_RULES.md`)
+- Rules template: `.claude/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced by a plain path pointer, not `@`-referenced — see step 5)
 - Antigen ledger: `.claude/remember/ledger.json` (per-rule evidence trail: class, status, attempts/rejected-buffer, recurrence-while-hot)
 - Consolidation report: `.claude/remember/report.md` (latest step-8 report, overwritten each run)
 - Processed manifest: `.claude/remember/.processed`

--- a/packages/droid/commands/docs-builder.md
+++ b/packages/droid/commands/docs-builder.md
@@ -747,7 +747,13 @@ Writes **one** `docs/index.md` covering the whole corpus, in three sections: `##
 (one row per file under `docs/product/`, plus any pages under `PAGES` — default `docs/wiki/`
 — if they exist, plus any doc still sitting in place elsewhere), `## Logs` (one row per file
 under `docs/logs/`), and `## Archive` (one row per file under `docs/archive/`). Each row is
-an H1 title, a line count, and a link. No theme grouping, no `labels.json`, no model call.
+an H1 title, a line count, and a link, plus one indented line per H2 heading (in document
+order) so an agent can find and slice-read a section without opening the doc — each H2
+line carries its own `(Lstart–end)` line range, reusing the SAME `headings()`+`fenceMask()`
+boundaries `scan` already writes to `outline.json` (no second parser). Omitted when the doc
+has no H2s. `## Archive` rows are H1-only, never H2 lines — an archived doc is frozen
+history, not a live section to route into. No theme grouping, no `labels.json`, no model
+call.
 Default destination `docs/index.md` — **the only writer of that default path** in this whole
 pipeline (nothing else writes an index at all).
 `search` reads `outline.json`, never `index.md`. Prints the row counts and records a `log.md`

--- a/packages/droid/commands/docs-builder/docs-builder.cjs
+++ b/packages/droid/commands/docs-builder/docs-builder.cjs
@@ -728,14 +728,33 @@ function plan(outlineF, labelsF) {
 // tripwire, never a prune, never a collapse, never a delete.
 const ARCHIVE_WARN_ROWS = 100; // stated default, not measured — see docs-builder-v3-spec.md
 
-function indexRow(rel, dest) {
+// `includeH2` is false for archive rows: an archived doc is frozen history, not a live
+// section a reader is being routed into, so its row stays H1 + line count + link only.
+function indexRow(rel, dest, includeH2) {
   const text = read(rel);
-  const h1 = (text.split('\n').find(l => l.startsWith('# ')) || '').slice(2).trim();
-  const lines = text.split('\n').length;
+  const lines = text.split('\n');
+  // Same headings()+fenceMask() path scan() uses -- no second parser -- so an H2 inside a
+  // ``` fence is masked out here exactly as it is there.
+  const mask = fenceMask(lines);
+  const { h1, heads } = headings(lines, mask);
   // Read from INSIDE index.md, so the link must resolve relative to index.md's own
   // directory, not the repo root.
   const relLink = path.relative(path.dirname(dest), repoPath(rel)).split(path.sep).join('/');
-  return `- [${h1 || path.basename(rel)}](${relLink}) — ${lines} lines\n`;
+  let row = `- [${h1 || path.basename(rel)}](${relLink}) — ${lines.length} lines\n`;
+  if (!includeH2) return row;
+  // One line per H2, each with its own line range: from the `## ` heading's own 1-based
+  // line through the line before the next heading of level <= 2 (H1 or H2), or EOF for the
+  // last one -- the SAME boundary scan() uses to write s/e into outline.json, re-derived
+  // here from the same heads array rather than duplicated as a second computation. Lets an
+  // agent jump straight to (and slice-read) a section without opening the doc at all.
+  const boundaries = heads.filter(h => h.lvl <= 2);
+  boundaries.forEach((h, i) => {
+    if (h.lvl !== 2) return;
+    const start = h.line;
+    const end = i + 1 < boundaries.length ? boundaries[i + 1].line - 1 : lines.length;
+    row += `  - ${h.text} (L${start}–${end})\n`;
+  });
+  return row;
 }
 
 function renderSection(title, rows) {
@@ -767,9 +786,10 @@ function indexFlat() {
   const outRel = process.env.OUT || 'docs/index.md';
   const dest = repoPath(outRel);
   const productRows = [...productFiles, ...pageFiles].sort()
-    .map(f => ({ file: f, row: indexRow(f, dest) }));
-  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
-  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
+    .map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  // Archive rows are deliberately H1-only -- frozen history, not a live section to route into.
+  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, false) }));
 
   let s = '# Index\n\n';
   // Unconditional — not gated on row count, unlike ARCHIVE_WARN_ROWS below: a reader should

--- a/packages/droid/commands/remember.md
+++ b/packages/droid/commands/remember.md
@@ -346,12 +346,13 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      inline duplication is needed
    - If `.factory/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers:
+     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
+     — an `@`-reference hot-loads the whole file into every session, and this is a standards
+     guide to consult when designing/building something new, not hot context:
      ```
      <!-- AGENT_RULES:START -->
-     Consult when building something new or adding a feature — a standards guide, not hot
-     context like MEMORY.md above:
-     @.factory/remember/AGENT_RULES.md
+     Standards guide (read when designing/building something new, not hot context):
+     .factory/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENTS.md already has a given pair, replace the
@@ -411,11 +412,12 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
 6. **Update processed manifest**
    - Append paths of newly processed stashes to `.factory/remember/.processed`
 
-7. **Docs reconcile check — DETECT ONLY** (best-effort, crash-isolated like step 0)
+7. **Docs reconcile check + auto re-index** (best-effort, crash-isolated like step 0)
 
-   `/remember` never reconciles docs, never writes frontmatter, never edits a page. It
-   prints at most one nudge line. Wrapped so any failure here can never block the memory
-   write that already happened in steps 3-6.
+   `/remember` never reconciles doc CONTENT, never writes frontmatter, never edits a page —
+   the only write here is the generated `docs/index.md` itself, via the same deterministic
+   `index-flat` script `/docs-builder` already uses, never a model call. Wrapped so any
+   failure here can never block the memory write that already happened in steps 3-6.
 
    - **Locate `docs-builder.cjs`** — bundled next to this command at
      `docs-builder/docs-builder.cjs` (same convention as `remember/friction.cjs`). Call it by
@@ -444,7 +446,19 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
    - If `due` prints "no ledger yet" (no `docs/.docs-builder/ledger.json` to compare against),
      do NOT relay it — print the same `/docs-builder reorg` line as the no-`docs/.docs-builder/`
      case above, for the same reason: `ledger` would stamp an unsorted pile as correct.
-   - If DUE, end with one line and nothing more:
+   - **Auto re-index — script only, no model, in addition to the DUE advisory below, not a
+     replacement for it.** If `due`'s output was NOT `docs unchanged since <sha>. NOT due.`
+     (i.e. it printed a row table -- any new/moved/moved+changed/changed/deleted doc, whether
+     or not the >=5 threshold below was crossed), the index has drifted and self-heals right
+     here, unconditionally:
+     ```bash
+     node <docs-builder.cjs> index-flat
+     ```
+     Same script `/docs-builder reorg` already calls, run standalone — no model call, no
+     interview, nothing moves. Note in the step-8 report that `docs/index.md` (and
+     `docs/log.md`, if `index-flat` touched it) were regenerated, so they are included
+     alongside whatever step 3-6 already changed when this run is committed.
+   - If DUE (the row count crossed the >=5 threshold), ALSO end with one line:
      ```
      docs: 7 changed since 991f72d3 — run /docs-builder reorg
      ```
@@ -489,12 +503,14 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      ledger: ag-002 "literal scoped ask"         ESCALATED → Fact; 2 phrasings failed. Hook or accept?
      ```
    - If AGENT_RULES.md was bootstrapped this run, say so (one line)
+   - If step 7 ran the auto re-index, say so and name the regenerated files
+     (`docs/index.md`, plus `docs/log.md` if touched) so they are staged with this run
    - Confirm MEMORY.md and AGENTS.md updated
 
 **File locations (all project-local — two dirs: `/stash` owns `.factory/stash/`, `/remember` owns `.factory/remember/`)**
 - Stash files: `.factory/stash/*.md`
 - Memory file: `.factory/remember/MEMORY.md` (single source of truth, referenced as `@.factory/remember/MEMORY.md`)
-- Rules template: `.factory/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced as `@.factory/remember/AGENT_RULES.md`)
+- Rules template: `.factory/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced by a plain path pointer, not `@`-referenced — see step 5)
 - Antigen ledger: `.factory/remember/ledger.json` (per-rule evidence trail: class, status, attempts/rejected-buffer, recurrence-while-hot)
 - Consolidation report: `.factory/remember/report.md` (latest step-8 report, overwritten each run)
 - Processed manifest: `.factory/remember/.processed`

--- a/packages/opencode/command/docs-builder.md
+++ b/packages/opencode/command/docs-builder.md
@@ -747,7 +747,13 @@ Writes **one** `docs/index.md` covering the whole corpus, in three sections: `##
 (one row per file under `docs/product/`, plus any pages under `PAGES` — default `docs/wiki/`
 — if they exist, plus any doc still sitting in place elsewhere), `## Logs` (one row per file
 under `docs/logs/`), and `## Archive` (one row per file under `docs/archive/`). Each row is
-an H1 title, a line count, and a link. No theme grouping, no `labels.json`, no model call.
+an H1 title, a line count, and a link, plus one indented line per H2 heading (in document
+order) so an agent can find and slice-read a section without opening the doc — each H2
+line carries its own `(Lstart–end)` line range, reusing the SAME `headings()`+`fenceMask()`
+boundaries `scan` already writes to `outline.json` (no second parser). Omitted when the doc
+has no H2s. `## Archive` rows are H1-only, never H2 lines — an archived doc is frozen
+history, not a live section to route into. No theme grouping, no `labels.json`, no model
+call.
 Default destination `docs/index.md` — **the only writer of that default path** in this whole
 pipeline (nothing else writes an index at all).
 `search` reads `outline.json`, never `index.md`. Prints the row counts and records a `log.md`

--- a/packages/opencode/command/docs-builder/docs-builder.cjs
+++ b/packages/opencode/command/docs-builder/docs-builder.cjs
@@ -728,14 +728,33 @@ function plan(outlineF, labelsF) {
 // tripwire, never a prune, never a collapse, never a delete.
 const ARCHIVE_WARN_ROWS = 100; // stated default, not measured — see docs-builder-v3-spec.md
 
-function indexRow(rel, dest) {
+// `includeH2` is false for archive rows: an archived doc is frozen history, not a live
+// section a reader is being routed into, so its row stays H1 + line count + link only.
+function indexRow(rel, dest, includeH2) {
   const text = read(rel);
-  const h1 = (text.split('\n').find(l => l.startsWith('# ')) || '').slice(2).trim();
-  const lines = text.split('\n').length;
+  const lines = text.split('\n');
+  // Same headings()+fenceMask() path scan() uses -- no second parser -- so an H2 inside a
+  // ``` fence is masked out here exactly as it is there.
+  const mask = fenceMask(lines);
+  const { h1, heads } = headings(lines, mask);
   // Read from INSIDE index.md, so the link must resolve relative to index.md's own
   // directory, not the repo root.
   const relLink = path.relative(path.dirname(dest), repoPath(rel)).split(path.sep).join('/');
-  return `- [${h1 || path.basename(rel)}](${relLink}) — ${lines} lines\n`;
+  let row = `- [${h1 || path.basename(rel)}](${relLink}) — ${lines.length} lines\n`;
+  if (!includeH2) return row;
+  // One line per H2, each with its own line range: from the `## ` heading's own 1-based
+  // line through the line before the next heading of level <= 2 (H1 or H2), or EOF for the
+  // last one -- the SAME boundary scan() uses to write s/e into outline.json, re-derived
+  // here from the same heads array rather than duplicated as a second computation. Lets an
+  // agent jump straight to (and slice-read) a section without opening the doc at all.
+  const boundaries = heads.filter(h => h.lvl <= 2);
+  boundaries.forEach((h, i) => {
+    if (h.lvl !== 2) return;
+    const start = h.line;
+    const end = i + 1 < boundaries.length ? boundaries[i + 1].line - 1 : lines.length;
+    row += `  - ${h.text} (L${start}–${end})\n`;
+  });
+  return row;
 }
 
 function renderSection(title, rows) {
@@ -767,9 +786,10 @@ function indexFlat() {
   const outRel = process.env.OUT || 'docs/index.md';
   const dest = repoPath(outRel);
   const productRows = [...productFiles, ...pageFiles].sort()
-    .map(f => ({ file: f, row: indexRow(f, dest) }));
-  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
-  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest) }));
+    .map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  const logsRows = logsFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, true) }));
+  // Archive rows are deliberately H1-only -- frozen history, not a live section to route into.
+  const archiveRows = archiveFiles.sort().map(f => ({ file: f, row: indexRow(f, dest, false) }));
 
   let s = '# Index\n\n';
   // Unconditional — not gated on row count, unlike ARCHIVE_WARN_ROWS below: a reader should

--- a/packages/opencode/command/remember.md
+++ b/packages/opencode/command/remember.md
@@ -346,12 +346,13 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      inline duplication is needed
    - If `.opencode/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers:
+     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
+     — an `@`-reference hot-loads the whole file into every session, and this is a standards
+     guide to consult when designing/building something new, not hot context:
      ```
      <!-- AGENT_RULES:START -->
-     Consult when building something new or adding a feature — a standards guide, not hot
-     context like MEMORY.md above:
-     @.opencode/remember/AGENT_RULES.md
+     Standards guide (read when designing/building something new, not hot context):
+     .opencode/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENTS.md already has a given pair, replace the
@@ -411,11 +412,12 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
 6. **Update processed manifest**
    - Append paths of newly processed stashes to `.opencode/remember/.processed`
 
-7. **Docs reconcile check — DETECT ONLY** (best-effort, crash-isolated like step 0)
+7. **Docs reconcile check + auto re-index** (best-effort, crash-isolated like step 0)
 
-   `/remember` never reconciles docs, never writes frontmatter, never edits a page. It
-   prints at most one nudge line. Wrapped so any failure here can never block the memory
-   write that already happened in steps 3-6.
+   `/remember` never reconciles doc CONTENT, never writes frontmatter, never edits a page —
+   the only write here is the generated `docs/index.md` itself, via the same deterministic
+   `index-flat` script `/docs-builder` already uses, never a model call. Wrapped so any
+   failure here can never block the memory write that already happened in steps 3-6.
 
    - **Locate `docs-builder.cjs`** — bundled next to this command at
      `docs-builder/docs-builder.cjs` (same convention as `remember/friction.cjs`). Call it by
@@ -444,7 +446,19 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
    - If `due` prints "no ledger yet" (no `docs/.docs-builder/ledger.json` to compare against),
      do NOT relay it — print the same `/docs-builder reorg` line as the no-`docs/.docs-builder/`
      case above, for the same reason: `ledger` would stamp an unsorted pile as correct.
-   - If DUE, end with one line and nothing more:
+   - **Auto re-index — script only, no model, in addition to the DUE advisory below, not a
+     replacement for it.** If `due`'s output was NOT `docs unchanged since <sha>. NOT due.`
+     (i.e. it printed a row table -- any new/moved/moved+changed/changed/deleted doc, whether
+     or not the >=5 threshold below was crossed), the index has drifted and self-heals right
+     here, unconditionally:
+     ```bash
+     node <docs-builder.cjs> index-flat
+     ```
+     Same script `/docs-builder reorg` already calls, run standalone — no model call, no
+     interview, nothing moves. Note in the step-8 report that `docs/index.md` (and
+     `docs/log.md`, if `index-flat` touched it) were regenerated, so they are included
+     alongside whatever step 3-6 already changed when this run is committed.
+   - If DUE (the row count crossed the >=5 threshold), ALSO end with one line:
      ```
      docs: 7 changed since 991f72d3 — run /docs-builder reorg
      ```
@@ -489,12 +503,14 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      ledger: ag-002 "literal scoped ask"         ESCALATED → Fact; 2 phrasings failed. Hook or accept?
      ```
    - If AGENT_RULES.md was bootstrapped this run, say so (one line)
+   - If step 7 ran the auto re-index, say so and name the regenerated files
+     (`docs/index.md`, plus `docs/log.md` if touched) so they are staged with this run
    - Confirm MEMORY.md and AGENTS.md updated
 
 **File locations (all project-local — two dirs: `/stash` owns `.opencode/stash/`, `/remember` owns `.opencode/remember/`)**
 - Stash files: `.opencode/stash/*.md`
 - Memory file: `.opencode/remember/MEMORY.md` (single source of truth, referenced as `@.opencode/remember/MEMORY.md`)
-- Rules template: `.opencode/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced as `@.opencode/remember/AGENT_RULES.md`)
+- Rules template: `.opencode/remember/AGENT_RULES.md` (bootstrapped once from the bundled package template on first `/remember` run, never overwritten again — user-owned after that; referenced by a plain path pointer, not `@`-referenced — see step 5)
 - Antigen ledger: `.opencode/remember/ledger.json` (per-rule evidence trail: class, status, attempts/rejected-buffer, recurrence-while-hot)
 - Consolidation report: `.opencode/remember/report.md` (latest step-8 report, overwritten each run)
 - Processed manifest: `.opencode/remember/.processed`

--- a/tests/docs-builder/docs-builder.test.js
+++ b/tests/docs-builder/docs-builder.test.js
@@ -1117,6 +1117,78 @@ function indexFlatCmd() {
   okTrue('no index.md is written for an empty corpus', !exists(empty, 'docs/index.md'));
 }
 
+/** Each row must also carry the doc's H2s as one indented continuation line, so an agent can
+ *  find a section without opening the doc. Must reuse the SAME headings()/fenceMask() path
+ *  scan() uses -- no second parser -- so a heading inside a ``` fence must not appear, and a
+ *  doc with zero H2s must emit no continuation line at all. */
+function indexFlatH2Continuation() {
+  group('22a. index-flat — H2 lines under each row, with line ranges');
+
+  const threeH2 = '# Three\n\nintro\n\n## Section A\n\nbody a\n\n## Section B\n\nbody b\n\n'
+    + '## Section C\n\nbody c\n';
+  const fencedH2 = '# Fenced\n\nintro\n\n## Real Section\n\nbody\n\n```\n## Not A Heading\n```\n';
+  const noH2 = '# NoHeadings\n\njust prose, no H2 at all\n';
+  const twoH2 = '# Two\n\n## First\n\nfirst body\n\n## Second\n\nsecond body\n';
+  const archivedWithH2 = '# Archived\n\n## Old Section\n\nstale body\n';
+
+  const d = repo({
+    'docs/product/Three.md': threeH2,
+    'docs/product/Fenced.md': fencedH2,
+    'docs/product/NoHeadings.md': noH2,
+    'docs/product/Two.md': twoH2,
+    'docs/archive/Archived.md': archivedWithH2,
+  });
+  const r = db(d, ['index-flat'], { OUT: 'docs/index.md' });
+  ok('index-flat exits clean', r.code, 0);
+  const md = read(d, 'docs/index.md');
+  const lines = md.split('\n');
+
+  // (1) a doc with 3 H2s -> one indented line per H2, in order, with `Ls–e` ranges computed
+  // from the SAME line indices headings() returns (reused, not re-derived): the `## `
+  // heading's own 1-based line through the line before the next heading of level <= 2, or
+  // EOF for the last one. Blank lines in the fixture below are load-bearing for these exact
+  // numbers -- verified against a plain node split('\n') of the fixture string.
+  const threeIdx = lines.findIndex(l => l.includes('[Three]'));
+  okTrue('Three row found', threeIdx >= 0);
+  ok('Three: 3 H2 lines with correct ranges, in order', threeIdx >= 0
+    ? [lines[threeIdx + 1], lines[threeIdx + 2], lines[threeIdx + 3]].join('|') : '(row not found)',
+    ['  - Section A (L5–8)', '  - Section B (L9–12)', '  - Section C (L13–16)'].join('|'));
+
+  // (a) a doc with 2 H2s where the 2nd runs to EOF -> its range's end is the file's last line.
+  const twoIdx = lines.findIndex(l => l.includes('[Two]'));
+  okTrue('Two row found', twoIdx >= 0);
+  ok('Two: 2nd H2 range runs to EOF', twoIdx >= 0
+    ? [lines[twoIdx + 1], lines[twoIdx + 2]].join('|') : '(row not found)',
+    ['  - First (L3–6)', '  - Second (L7–10)'].join('|'));
+
+  // (2) a doc with an H2 inside a ``` fence -> that heading is absent, only the real one
+  // shows, and its range runs to EOF (the fenced "heading" is masked, so nothing bounds it).
+  const fencedIdx = lines.findIndex(l => l.includes('[Fenced]'));
+  okTrue('Fenced row found', fencedIdx >= 0);
+  ok('Fenced: only the real H2 shows, fenced one absent, range to EOF',
+    fencedIdx >= 0 ? lines[fencedIdx + 1] : '(row not found)',
+    '  - Real Section (L5–12)');
+  okTrue('fenced "Not A Heading" never appears anywhere in index.md',
+    !md.includes('Not A Heading'));
+
+  // (3) a doc with no H2s -> no continuation line at all.
+  const noH2Idx = lines.findIndex(l => l.includes('[NoHeadings]'));
+  okTrue('NoHeadings row found', noH2Idx >= 0);
+  okTrue('NoHeadings row: no continuation line follows (next line is not "  - " indented)',
+    noH2Idx >= 0 && !lines[noH2Idx + 1].startsWith('  - '));
+
+  // (b) an archived doc WITH H2s -> the row still appears under ## Archive, but gets NO H2
+  // lines at all (H1 + line count + link only) -- archive rows are deliberately H1-only.
+  const archiveSection = md.split(/^## /m).find(s => s.startsWith('Archive')) || '';
+  const archiveLines = archiveSection.split('\n');
+  const archivedIdx = archiveLines.findIndex(l => l.includes('[Archived]'));
+  okTrue('Archived row found under ## Archive', archivedIdx >= 0);
+  okTrue('Archived row: no H2 continuation line, despite having an H2',
+    archivedIdx >= 0 && !archiveLines[archivedIdx + 1].startsWith('  - '));
+  okTrue('"Old Section" heading text never appears anywhere in index.md (archive rows are H1-only)',
+    !md.includes('Old Section'));
+}
+
 /** Regression test that matters most: every link index-flat writes must resolve to a real
  *  file on disk, for every section, walked and stat'd — not spot-checked. */
 function indexFlatLinksResolve() {
@@ -2579,7 +2651,7 @@ function main() {
     tasksDirChokepoint, halfFinishedSplitDetection,
     reorgCorpusStability, reorgOutIgnored,
     archiveStandaloneFollowup,
-    indexFlatCmd, indexFlatLinksResolve, indexArchiveWarnFlag, applyReorgAutoIndexes,
+    indexFlatCmd, indexFlatH2Continuation, indexFlatLinksResolve, indexArchiveWarnFlag, applyReorgAutoIndexes,
     indexFlatSearchHint, claudeMdDocsPointer, applyReorgConfigPointerBugs,
     relativeInboundLinks, relativeLinksBothMove, archiveIsFrozen, archiveOrderingBug,
     applyReorgScansWholeCorpus, applyReorgScanRespectsPages, applyReorgScansOversizedInPlace,


### PR DESCRIPTION
## Summary
- `index-flat`: each Product/Logs row now lists the doc's H2 headings, one per line, with `(L<start>–<end>)` — same `headings()`/`fenceMask()` boundaries `scan` writes to `outline.json`; archive rows stay H1-only
- `/remember` step 7: any drift row from `due` re-runs `index-flat` (script only, no model); the ≥5 REORG-IS-DUE advisory is unchanged
- `AGENT_RULES.md` is a plain path pointer in the inject step and this repo's CLAUDE.md, no longer an `@` include (~6.5k tokens/session was hot-loaded despite being documented as not hot); `MEMORY.md` stays `@`
- 2.18.0 → 2.19.0

## Verification
- Group 22a fails 4 assertions against pre-change code, passes after; suite 960/960
- Live on zkagent: regenerated `docs/index.md` has 31 H2 lines matching `outline.json` (file, h2, s, e) 31/31
- `docs-builder.cjs` byte-identical across 4 packages; `remember.md` 0 non-path diffs; `~/.claude` copies identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwvtdQ1dYRzQvpUAYMv5s5