### PR TITLE
v2.23.0 — refactor guardrails, fix-ledger closure, remember known limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [2.23.0] - 2026-09-02
 
 ### Added
 - **`/refactor` gains a no-argument ledger mode.** Bare `/refactor` works through
@@ -39,6 +39,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/product/branch-review-README.md`** — reference for the pre-merge gate: the three
   stages, what blocks a merge, the ledger's anchor design, and the review → ledger →
   `/refactor` loop. Follows the existing `remember` and `docs-builder` product-doc pattern.
+- **`/refactor` gains a `## Guardrails` block, ported from `/branch-review`.** Spawn a
+  worker at your tool's mid tier, stated explicitly on the spawn; escalate anything you
+  cannot decide rather than assuming; the worker never sub-delegates; edit only what a
+  surviving ledger bullet names, one change per bullet. The three parts that do not
+  transfer verbatim were rewritten: "no edits" inverts into a scope rule since `/refactor`
+  edits by design, and **the three HITL gates belong to the orchestrator, not the
+  worker** — a subagent cannot hold a conversation, so it stops and hands back the options
+  with no choice made rather than picking revert/patch/update-test on the user's behalf.
+  The blast-radius proof is now two checks: `git status --porcelain` at exit must list
+  only bullet-named files, and `md5sum .claude/remember/*` must show only `fix-ledger.md`
+  differing — `last-review.md` is off-limits to the fixer, since writing it would forge
+  the gate that judges its own work.
+- **`docs/product/remember-README.md`** gains a `## 6. Known limitations` section.
+  Matching semantics and evidence are the same channel — an entry's `class_hints` are
+  fragments of the quotes that proved it, so its identity and its proof of recurrence are
+  the same strings — with two consequences pulling in opposite directions: tautological
+  matching (bounded, not removed, by session-hash dedup) and over-matching on thin
+  ledgers (`Open item 2`). Separately: a run cannot tell that its own work invalidated a
+  standing fact, since detecting that would mean re-checking every fact against the
+  working tree on every run, which trades a stale fact for a confidently wrong one.
 
 ### Changed
 - **`/branch-review` writes a durable review record; `/release` reads it.** The reviewed
@@ -128,6 +148,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/branch-review` — ledger bullets are subject to stage 3.** A field run produced a true
   finding whose stated consequence was false. Bullets must now be verified or carry an
   `UNVERIFIED:` prefix so `/refactor` retests before acting.
+- **`/remember` — a marker pair already present in `CLAUDE.md` had no rule.** The clause
+  covered a missing pair (append it) and the AGENT_RULES exception (leave it alone) but
+  said nothing for an already-present MEMORY pair, which is the common case on every run
+  after the first. Now: replace its content in place; the AGENT_RULES bootstrap-once
+  exception directly below still overrides.
+- **`docs/product/branch-review-README.md`** — dropped a stale "five-line record" count.
+  The record stopped being five lines once level, coverage and blockers were added.
+- **`/refactor` — ledger mode's step 1 caught a dirty tree only after a worker already
+  existed.** Step 1 now documents the split: the orchestrator runs the tree check before
+  spawning, and the worker re-runs it as its own first act, matching `/branch-review`'s
+  Target section.
 
 ## [2.22.1] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/refactor` gains a no-argument ledger mode.** Bare `/refactor` works through
+  `.claude/remember/fix-ledger.md` instead of taking a target: it requires a clean tree and
+  a non-`main` branch, revalidates every bullet before fixing anything, drops the ones
+  whose anchor no longer resolves, fixes the survivors one at a time under the existing
+  no-behaviour-change constraints, and deletes each bullet as its fix lands — so the fix
+  commit is the done record and there is no second place to keep it in sync.
+- **`/branch-review` gains State ownership as a stage-1 finding category.** Two or more
+  functions assigning the same field, flag or view property is a finding on its own, with
+  no failing case required. Both writers must be named with `file:line`, since an unnamed
+  second writer is a hunch. Ordering counts as well as writers: a write arriving from a
+  callback, thread or lifecycle event is the dangerous one, and one app writer racing a
+  framework writer still counts as two.
+- **`AGENT_RULES.md` — four Build Rules, each naming something observable.** One writer per
+  piece of state; split the decision from the machinery, extracting a branch into a pure
+  function to pin it with a test rather than to raise coverage; claims in comments must be
+  checkable, because a name search proves an edge exists and never that one does not; and
+  every line earns its place, meaning if you cannot say what breaks when it is deleted,
+  delete it. "Surgical changes only" was rewritten to say what to do with a problem you
+  pass on the way: fix it if it is in the code you are already changing and the fix changes
+  no behaviour, otherwise report it with what it costs to leave. A problem you do not fix
+  goes in the report, never in a comment.
+- **`/remember` writes two hot rules inline into the `AGENT_RULES.md` section.** The file
+  stays a plain pointer and is never `@`-referenced, since that hot-loads roughly 300 lines
+  of standards guide into every session. The section now carries the path plus exactly the
+  two rules that change what you type — the ones you cannot look up because you do not know
+  you need them.
+- **`docs/product/branch-review-README.md`** — reference for the pre-merge gate: the three
+  stages, what blocks a merge, the ledger's anchor design, and the review → ledger →
+  `/refactor` loop. Follows the existing `remember` and `docs-builder` product-doc pattern.
+
 ### Changed
 - **`/branch-review` writes a durable review record; `/release` reads it.** The reviewed
   SHA previously existed only as prose in a chat message, so `/release`'s Phase 0.5
@@ -28,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole branch, which is what makes a review converge instead of surfacing a fresh nit
   list every run. Style, wording and structure never block; a normative requirement stated
   two incompatible ways still does, since conforming implementations built from it diverge.
+
+- **`/release` Phase 0.5 is the SHA comparison alone.** A ledger-only exception was removed
+  rather than kept and narrowed: the ledger is gitignored, so it never reaches a commit
+  diff, and scoping a rule to a condition that cannot occur is how dead branches survive
+  review. A repo that does track `.claude/` will see a ledger commit make the review stale,
+  which is the gate working — re-review, or leave the ledger uncommitted until the release
+  is cut.
 
 ### Fixed
 - **`/ship` and `/branch-review` — exit codes must be read off the bare command, not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is cut.
 
 ### Fixed
+- **`/release` Phase 0.5 wrote a `verdict:` line nobody read.** The record carried the
+  review's conclusion, but the gate compared only the `sha:` line, so a record saying
+  `verdict: blocked` passed the mechanical check whenever the hash still matched — leaving
+  the conclusion to the orchestrator's recollection, which is the unverified claim the
+  record was created to replace. Both lines are now read mechanically; only `ready` plus a
+  matching hash is a pass.
 - **`/release` — the handoff sequence went from `gh pr create` straight to `gh pr merge`,
   with no wait for CI.** Every gate in the chain runs on one machine: `/branch-review`
   reviews locally, `/ship` runs the suite locally, and `/release` never pushes. CI is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`/branch-review` writes a durable review record; `/release` reads it.** The reviewed
+  SHA previously existed only as prose in a chat message, so `/release`'s Phase 0.5
+  precondition resolved to the orchestrator's word — the one party the same paragraph
+  declares inadmissible — and vanished on a compaction or a handover. The review now
+  overwrites `.claude/remember/last-review.md` with sha/branch/target/verdict/date, and
+  Phase 0.5 matches against its `sha:` line. No record, or no `sha:` line, is no review.
+
+  **Migration:** a branch reviewed before this change has no record file, so the new
+  Phase 0.5 will correctly refuse it. That is migration, not a bug. Re-run
+  `/branch-review`; do **not** hand-write the record, which would turn the durable
+  artifact back into the unverified claim it exists to replace.
+
+- **Only reproduced Critical/High failures block a merge.** Everything else is appended
+  to a local fix ledger at `.claude/remember/fix-ledger.md`, consumed by bare `/refactor`.
+  Re-review after fixes reads `<previously-reviewed-sha>..HEAD` rather than re-judging the
+  whole branch, which is what makes a review converge instead of surfacing a fresh nit
+  list every run. Style, wording and structure never block; a normative requirement stated
+  two incompatible ways still does, since conforming implementations built from it diverge.
+
+### Fixed
+- **`/ship` and `/branch-review` — exit codes must be read off the bare command, not a
+  pipeline.** `$?` after a pipe is the last element's status, so the natural multi-suite
+  shape `out=$(cmd 2>&1 | tail -1); echo "exit=$?"` records `tail`'s success for a suite
+  that exited non-zero. Found in the field: a check printing "exit 2: prerequisites
+  missing" entered the gate as a pass. `${PIPESTATUS[0]}` does not rescue it inside a
+  command substitution either.
+- **`/branch-review` — ledger dedupe uses plain `grep`, not `git grep`.** The ledger is
+  deliberately gitignored and `git grep` searches tracked content only, so the dedupe
+  check reported "not found" for snippets sitting in the file and would have re-appended
+  every finding on every run.
+- **`/branch-review` — ledger bullets are subject to stage 3.** A field run produced a true
+  finding whose stated consequence was false. Bullets must now be verified or carry an
+  `UNVERIFIED:` prefix so `/refactor` retests before acting.
+
 ## [2.22.1] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is cut.
 
 ### Fixed
+- **`/release` — the handoff sequence went from `gh pr create` straight to `gh pr merge`,
+  with no wait for CI.** Every gate in the chain runs on one machine: `/branch-review`
+  reviews locally, `/ship` runs the suite locally, and `/release` never pushes. CI is the
+  only differently-configured instrument, and under this flow it sees the branch for the
+  first time *after* both gates have passed. Found in the field: a release merged and
+  tagged on green local gates, then failed CI on a test asserting against a path that
+  exists only on the author's machine, leaving a tag cut but never published — the exact
+  "local ahead of published" state Phase 0 warns about. The sequence now has a
+  `gh pr checks --watch` step between create and merge, and merges only on green.
+- **`/release` — the exit-code rule applies to the orchestrator's own shell too.** `/ship`
+  carried it for the worker, but the handoff steps are typed by hand and were not covered.
+  In the same field run, `gh run watch --exit-status | tail -2; echo $?` printed `0` for a
+  failed run, turning a red CI into a green reading.
+- **`/release` — the docs sweep may fix a line a ledger bullet names, but must not delete
+  the bullet.** Calling the sweep the place to "close" a doc-only item made `/release` a
+  second deleter of state with exactly one owner, contradicting both the ledger's
+  one-append-one-delete split and the one-writer-per-state build rule this release adds.
+  The sweep still fixes the line; `/refactor`'s next revalidation drops the bullet.
+- **`/branch-review` — the exit-cleanliness check could not see its own target.** The
+  guardrail said porcelain must be empty or list only the two allowed paths, but `.claude/`
+  is gitignored, so porcelain is empty whether the reviewer wrote those files, wrote
+  nothing, or overwrote `MEMORY.md`. `git status --ignored` does not close it either — it
+  collapses to the directory, not the files. Porcelain keeps its real job (no tracked file
+  changed); an `md5sum` comparison over `.claude/remember/` now covers the two writes.
 - **`/ship` and `/branch-review` — exit codes must be read off the bare command, not a
   pipeline.** `$?` after a pipe is the last element's status, so the natural multi-suite
   shape `out=$(cmd 2>&1 | tail -1); echo "exit=$?"` records `tail`'s success for a suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is cut.
 
 ### Fixed
+- **`/branch-review` — a disproved ledger bullet is deleted, and a dead run is not a
+  pass.** The append-only rule left nowhere to record that a bullet's stated consequence
+  was wrong: editing it broke the rule, and a second bullet read as a second finding. A
+  field session hit this and invented an indented sub-bullet. Disproof now deletes the
+  line, with the reason going in the report — the ledger is a work list, not an archive.
+  Separately, a review that dies mid-flight writes no record, and nothing said whether that
+  silence counted as a pass; it does not.
 - **`/branch-review` — the review record carries blockers, level and coverage.** Five lines
   proved that a review ran and what it concluded, but not *what* was blocked, so a session
   inheriting a `blocked` verdict had to re-review the branch to rediscover why — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is cut.
 
 ### Fixed
+- **`/branch-review` — the review record carries blockers, level and coverage.** Five lines
+  proved that a review ran and what it concluded, but not *what* was blocked, so a session
+  inheriting a `blocked` verdict had to re-review the branch to rediscover why — the
+  non-convergence this command exists to stop, displaced one level up. The record now lists
+  one line per blocker (claim only; scenarios stay in the report, non-blocking findings stay
+  in the ledger), the effort level, and per-stage coverage. `/release` stops on any stage
+  marked `NOT RUN`, since a `ready` from a run that skipped the security stage is a
+  different fact. Deliberately absent: any override field — a hash is checkable by anyone
+  and consent is not, so a consent line would be forgeable by whatever writes the file, and
+  a persisted override would silently cover the next release too.
 - **`/release` Phase 0.5 wrote a `verdict:` line nobody read.** The record carried the
   review's conclusion, but the gate compared only the `sha:` line, so a record saying
   `verdict: blocked` passed the mechanical check whenever the hash still matched — leaving

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 - **debug-method** - Four-phase debugging framework
 - **optimize** - Performance analysis
 - **refactor** - Safe refactoring with behavior preservation
-- **branch-review** - Pre-merge gate: general review at a chosen effort level plus a full security audit, adversarial verify pass; reports findings, never fixes
+- **branch-review** - Pre-merge gate: general review at a chosen effort level plus a full security audit, adversarial verify pass; only Critical/High block, the rest goes to a fix ledger; reports findings, never fixes, nudges `/refactor` when fixes are waiting
 - **security** - Standalone vulnerability scan; also runs as stage 2 of `/branch-review`
 - **ship** - Pre-deployment checklist
 - **release** - Prepare a release on the current branch: verify → docs sweep → version bump → local commit, then hand back the merge/tag/publish sequence (never pushes)
@@ -185,6 +185,7 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 ```
 @quality-assurance Review this PR before merge
 /branch-review main medium  # review branch vs main + security audit; reports, never fixes
+/refactor                   # no args: work through the fix ledger branch-review accumulated, between features
 /debug-method Investigate this race condition
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 - **skill-creator** - Guide for creating new skills
 - **debug-method** - Four-phase debugging framework
 - **optimize** - Performance analysis
-- **refactor** - Safe refactoring with behavior preservation
-- **branch-review** - Pre-merge gate: general review at a chosen effort level plus a full security audit, adversarial verify pass; only Critical/High block, the rest goes to a fix ledger; reports findings, never fixes, nudges `/refactor` when fixes are waiting
+- **refactor** - Safe refactoring with behavior preservation; with no arguments, works through the fix ledger `/branch-review` accumulated
+- **branch-review** - Pre-merge gate that reports and never fixes: general review at a chosen effort level, a full security audit that runs at full depth regardless of level, then an adversarial verify pass. Needs a clean tree. Only reproduced Critical/High failures block; everything else lands in the fix ledger for `/refactor`
 - **security** - Standalone vulnerability scan; also runs as stage 2 of `/branch-review`
 - **ship** - Pre-deployment checklist
 - **release** - Prepare a release on the current branch: verify → docs sweep → version bump → local commit, then hand back the merge/tag/publish sequence (never pushes)
@@ -166,6 +166,7 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 | **[subagentic-manual.md](packages/subagentic-manual.md)** | Detailed agent/command reference |
 | **[remember-README.md](docs/product/remember-README.md)** | How hot memory works — the `/stash` → `/remember` pipeline, the friction sensor, and the antigen ledger |
 | **[docs-builder-README.md](docs/product/docs-builder-README.md)** | How `/docs-builder` works — the reorg/cleanup modes, what it measurably costs, and the ledger that tracks doc drift |
+| **[branch-review-README.md](docs/product/branch-review-README.md)** | How the pre-merge gate works — the three stages, what blocks a merge, and the `/branch-review` → fix ledger → `/refactor` loop |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 - **refactor** - Safe refactoring with behavior preservation; with no arguments, works through the fix ledger `/branch-review` accumulated
 - **branch-review** - Pre-merge gate that reports and never fixes: general review at a chosen effort level, a full security audit that runs at full depth regardless of level, then an adversarial verify pass. Needs a clean tree. Only reproduced Critical/High failures block; everything else lands in the fix ledger for `/refactor`
 - **security** - Standalone vulnerability scan; also runs as stage 2 of `/branch-review`
-- **ship** - Pre-deployment checklist
-- **release** - Prepare a release on the current branch: verify → docs sweep → version bump → local commit, then hand back the merge/tag/publish sequence (never pushes)
+- **ship** - Mechanical pre-deploy gate: every item is answerable by running a command and reading its exit code, recorded as pass/fail/N/A. A check not run is a fail, and N/A needs a stated reason
+- **release** - Prepare a release on the current branch: verify → docs sweep → version bump → local commit, then hand back the merge/tag/publish sequence (never pushes). Refuses without a review recorded at the current HEAD SHA
 - **test-generate** - Generate test suites
 
 > **Claude-only plugin:** `live-canvas-channel` is a bundled Claude Code MCP channel plugin that ships under `~/.claude/plugins/live-canvas-marketplace/`. One-time `/plugin install` + a session started with `--dangerously-load-development-channels` unlocks live mode. Skill probes for the channel on each invocation and handholds setup when missing. See [`packages/claude/skills/live-canvas/README.md`](packages/claude/skills/live-canvas/README.md) for the full walkthrough.
@@ -185,7 +185,7 @@ Results land in `.claude/remember/friction/antigen_review.md` with projects, err
 **Code Quality:**
 ```
 @quality-assurance Review this PR before merge
-/branch-review main medium  # review branch vs main + security audit; reports, never fixes
+/branch-review main medium  # review + security audit; blockers reported, the rest to the fix ledger
 /refactor                   # no args: work through the fix ledger branch-review accumulated, between features
 /debug-method Investigate this race condition
 ```

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,3 +4,4 @@
 ## [2026-08-24] index-flat | 6 row(s) (5 product, 0 logs, 1 archive)
 ## [2026-08-28] index-flat | 6 row(s) (5 product, 0 logs, 1 archive)
 ## [2026-09-01] index-flat | 6 row(s) (5 product, 0 logs, 1 archive)
+## [2026-09-02] index-flat | 6 row(s) (5 product, 0 logs, 1 archive)

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -13,7 +13,7 @@ them. It is a **slash command**: `commands/branch-review.md`, no bundled script 
 check is a worker reading, running, and grepping the repo itself, the same shape as
 `/security`.
 
-**It never edits code.** Its one write is an append to a fix ledger. Fixing findings is a
+**It never edits code.** Its only writes are the fix ledger and the review record. Fixing findings is a
 separate, separately authorized action, handled by `/refactor` in ledger mode.
 
 ```
@@ -30,6 +30,16 @@ commit  ──►  /branch-review [target] [level]  ──►  fix ledger + bloc
 ---
 
 ## 1. What it guarantees
+
+**Two files, and proving it wrote nothing else.** The review's only writes are the fix
+ledger (§5) and the review record (§5b). Proving that takes two checks, because neither
+sees what the other does. `git status --porcelain`, at start and at exit, proves no
+*tracked* file changed — the never-edits-code guarantee, and the one that matters. It
+cannot see the review's own two writes: `.claude/` is normally gitignored, so porcelain
+stays empty whether the reviewer wrote the allowed files, wrote nothing, or overwrote
+`MEMORY.md`. `git status --ignored` does not close it either, collapsing to the directory
+rather than the files. An `md5sum` comparison over `.claude/remember/` before and after
+does, and only those two files may differ.
 
 - **Reports, never fixes.** The command may write exactly one file —
   `.claude/remember/fix-ledger.md` — and only by appending. Everything else it finds is
@@ -214,7 +224,24 @@ from a review run lands here as one bullet:
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
-### The review record
+---
+
+### One writer per operation
+`/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing
+bullet. `/refactor` in ledger mode **only deletes** — it revalidates and removes bullets as
+their fixes land or their anchors go stale, but it never adds one. Each command has
+exactly one write shape on this file, and no third command has any — `/release`'s docs
+sweep may well correct a line a bullet names, since that doc changed with the feature, but
+it leaves the bullet alone and the next revalidation drops it. That split matters because it makes the ledger
+readable as a log: an append is always new evidence from a review, a deletion is always a
+closed or invalidated item, and neither command can silently second-guess what the other
+recorded. If both could edit freely, a bug in either command could corrupt the other's
+half of the record with no way to tell which write did it.
+
+---
+
+
+## 5b. The review record
 
 `.claude/remember/last-review.md`, written at the end of every run and overwritten whole:
 
@@ -268,20 +295,6 @@ it would answer "not found" for a snippet that is present and the dedupe would s
 pass on every run. The anchor lookups against source files above are `git grep`, correctly
 — those files are tracked. Same flag, two different targets, only one of them in git.
 
-### One writer per operation
-`/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing
-bullet. `/refactor` in ledger mode **only deletes** — it revalidates and removes bullets as
-their fixes land or their anchors go stale, but it never adds one. Each command has
-exactly one write shape on this file, and no third command has any — `/release`'s docs
-sweep may well correct a line a bullet names, since that doc changed with the feature, but
-it leaves the bullet alone and the next revalidation drops it. That split matters because it makes the ledger
-readable as a log: an append is always new evidence from a review, a deletion is always a
-closed or invalidated item, and neither command can silently second-guess what the other
-recorded. If both could edit freely, a bug in either command could corrupt the other's
-half of the record with no way to tell which write did it.
-
----
-
 ## 6. `/refactor` with no arguments — ledger mode
 
 Bare `/refactor` (no code-section argument) works through the ledger instead of taking a
@@ -325,7 +338,17 @@ on its own report isn't.
 
 ## 8. Convergence — re-review without re-judging the whole branch
 
-**Re-review after fixes passes the range `<previously-reviewed-sha>..HEAD`.** Stage 1 then
+**A re-review reads the record first** (§5b) and branches on its `sha:` line — that line is
+where the previously-reviewed commit comes from, and its `blockers:` list is what stage 3
+owes an answer on. Taking either from whoever invoked the command would reintroduce the
+recollection problem the record exists to end.
+
+- **`sha:` ≠ HEAD** → re-review over `<that sha>..HEAD`.
+- **`sha:` = HEAD** → nothing changed; say so and stop rather than re-run an identical
+  tree. A recorded `blocked` verdict means its blockers are unfixed by definition.
+- **no file** → no prior review to build on; read the whole branch.
+
+**The range is `<previously-reviewed-sha>..HEAD`.** Stage 1 then
 reads only the fix commits; stage 3 re-verifies the prior report's blockers (fixed /
 unfixed / dismissed, with reason); the rest of the branch is **not** re-judged. The range
 form still ends at HEAD, so `/release`'s precondition is still satisfied.
@@ -361,6 +384,9 @@ whatever state the ledger file happens to be in.
   this commit; the verdict is what it concluded, and only `ready` plus a matching hash is a
   pass. Both lines are read mechanically, for the same reason: the alternative is trusting
   someone's memory of the outcome.
+- **`coverage:` naming any stage `NOT RUN`** → stop. A `ready` from a run whose security
+  stage never executed is not the same fact as one where it did, and this line is the only
+  place the difference is visible.
 - **No record file, or no `sha:` line in it** → no review, full stop: *"No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."*
 - **Recorded SHA ≠ current HEAD** (commits landed after the review, including fix
@@ -376,6 +402,15 @@ whatever state the ledger file happens to be in.
 
 This is the only thing guaranteeing the branch was reviewed *and* security-scanned before
 release, so a missing answer is always treated as a stop, never as a pass.
+
+**One gap the gate cannot close.** Every check in this chain runs on one machine:
+`/branch-review` reads locally, `/ship` runs the suite locally, `/release` never pushes. CI
+is the only differently-configured instrument, and it sees the branch for the first time
+*after* both gates pass. A test that is green locally because of a path, fixture or tool
+that exists only on the author's box fails there and nowhere earlier. `/release`'s hand-back
+sequence therefore puts `gh pr checks --watch` between opening the PR and merging, and
+merges only on green — read off the bare command, like every other exit code in that
+sequence, including the ones typed by hand.
 
 ---
 

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -169,7 +169,13 @@ failure scenario confirmed in stage 3.
   the actual exemption, not "prose": where the deliverable *is* a specification, a
   normative requirement stated two incompatible ways is a reproduced defect, because
   two conforming implementations built from it diverge. The test is whether a
-  behaviour changes, not whether the file holds code.
+  behaviour changes, not whether the file holds code — judged per finding, not per repo,
+  since a diff mixing code and specification is the normal case.
+
+  Expect a medium review of a few hundred lines to take on the order of ten to fifteen
+  minutes. The falsifiability proofs and the repo-wide security history scan dominate that,
+  and both are the parts worth paying for. A run that looks stalled at five minutes is
+  working.
 
 The report opens with the one-line verdict **before any section**: *Ready to merge? Yes /
 No / Not until these are fixed.* A report that opens with "Critical: none found" reads as

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -1,0 +1,361 @@
+---
+type: reference
+title: branch-review
+status: draft
+updated: 2026-09-02
+---
+
+# branch-review
+
+`/branch-review` is the pre-merge gate. It reads a branch, runs a general review and a
+full security audit against it, then tries to break its own findings before reporting
+them. It is a **slash command**: `commands/branch-review.md`, no bundled script — every
+check is a worker reading, running, and grepping the repo itself, the same shape as
+`/security`.
+
+**It never edits code.** Its one write is an append to a fix ledger. Fixing findings is a
+separate, separately authorized action, handled by `/refactor` in ledger mode.
+
+```
+commit  ──►  /branch-review [target] [level]  ──►  fix ledger + blocking findings
+                 ├─ stage 1: general review (effort-governed)
+                 ├─ stage 2: security (always full)
+                 └─ stage 3: verify (adversarial)
+                                                          │
+                                        /refactor (no args) ──► fixes, deletes bullets
+                                                          │
+                                                    /release Phase 0.5
+```
+
+---
+
+## 1. What it guarantees
+
+- **Reports, never fixes.** The command may write exactly one file —
+  `.claude/remember/fix-ledger.md` — and only by appending. Everything else it finds is
+  handed back as a finding. It re-runs `git status --porcelain` before reporting: empty,
+  or listing exactly the ledger path, or it says what else changed. That turns "it never
+  edits" from a claim into a checked fact, not an assertion.
+- **The worker does its own work.** The review subagent must not spawn subagents of its
+  own — everything it reports has to be something it personally read, ran, or grepped. A
+  relayed "I executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
+  is the entire point of the command. `/security` carries the identical rule inside its
+  own stage 2.
+- **Escalate, never assume.** Anything the worker cannot decide, cannot verify, or that
+  the spec doesn't cover goes back to the orchestrator. Never improvise, never widen
+  scope, never fix a side issue noticed along the way.
+
+---
+
+## 2. Target resolution
+
+**Before resolving anything, check the tree.** `git status --porcelain` must be empty. Any
+modified, staged, or untracked line is a **stop**, and the stop names three things, not
+just the first: the tree is dirty (with the paths), `/branch-review` reviews commits, not
+the working tree, and the remedy — commit the work, then re-run. It does not fall back to
+the staged diff or the working tree, and it does not review a subset. The most expensive
+failure this command can have is reviewing 800 committed lines while 200 uncommitted lines
+of today's actual work go unread.
+
+With a clean tree, `$ARGUMENTS` is interpreted in order:
+
+| Input | Resolves to |
+|---|---|
+| empty | current branch vs its merge-base with `main` (`git diff $(git merge-base main HEAD)..HEAD`); empty diff → say so and stop |
+| a range (`main..HEAD`, `origin/main...HEAD`) | `git diff <range>` |
+| a single ref (branch/tag/SHA, confirmed with `git rev-parse --verify`) | that ref's merge-base against `HEAD` |
+| a file or directory path | that target |
+| anything else | ask |
+
+The worker records the **HEAD SHA** it reviewed and reports the resolved target (the
+literal range or path), so the orchestrator sees what was actually read rather than
+assuming.
+
+**Why the tree must be clean first, always:** `/release`'s own precondition is a review at
+the current HEAD SHA, and any commit made after the review makes it stale. **The only
+correct order is commit → review → release.** A dirty tree reviewed anyway would mean the
+recorded SHA can never match what actually ends up on the branch.
+
+### Effort level
+`low | medium | high | max`, default **medium**. The level governs **stage 1 only**:
+
+- **low / medium** — fewer findings, only ones the worker is confident in.
+- **high / max** — broader coverage; uncertain findings are allowed, but each must be
+  labelled uncertain.
+
+**Stage 2 (security) always runs full, at every level.** A shallow security pass is worse
+than none — it reads as coverage while missing the class of bug that costs the most.
+
+---
+
+## 3. The three stages
+
+### Stage 1 — General review (effort-governed)
+The diff is the subject, but the worker reads the whole file around every hunk — a
+hunk-only read can't see that a caller further down the same file is now wrong. For
+multi-commit ranges it skims `git log <range>` for intent before judging.
+
+**Commit messages are claims, not evidence.** A message saying a fix was "proven
+red→green," a bug reproduced, or a test added is something to re-test, not accept.
+Branches are commonly AI-authored now — including the fixes to the fixes — so a review
+that trusts the message is reviewing prose. The worker runs the test suite and the
+typecheck/build itself and cites the command and its exit code.
+
+What it looks for: bugs needing a fix (logic errors, off-by-one, null paths, races, wrong
+defaults); dead code (`git grep` the symbol before flagging — easy to be wrong); loose
+ends (TODO/FIXME, half-finished branches, swallowed errors, stub bodies, abandoned feature
+flags); correctness (edge cases, error handling, broken invariants); **state ownership**
+(two or more functions assigning the same field/flag/view property is a finding on its
+own, no failing case required — `git grep` every assignment repo-wide, not just in the
+diff, since the second writer is usually in a file the diff never touched; name both
+writers with `file:line`, and count a write from a callback/thread/lifecycle event as a
+writer too); performance (N+1, blocking calls in hot paths, unbounded loops); test
+quality; maintainability (only when material).
+
+**Test quality is proven, not reasoned about.** For every test the diff adds or changes,
+the worker establishes it can actually fail — by reverting the source, not the test: pull
+the pre-change file with `git show <base-sha>:<path>` to a temp location *outside* the
+repo (the tree must stay clean at exit), run the test against that old version, and watch
+it go red. A test that passes against both the buggy and the fixed source is a tautology
+and proves nothing; every one found is flagged, and the report says explicitly when tests
+are the branch's only evidence for its own claims.
+
+### Stage 2 — Security (always full)
+`/branch-review` doesn't reimplement a checklist; it delegates. It locates and reads the
+installed `security.md` and runs its actual checks — the recurring six (secrets in the
+repo *and in git history*, data-access authorization / tenant isolation, rate limiting,
+unhappy-path error handling, authorization beyond authentication, inefficient data access)
+plus injection, auth/session, and trust boundaries. If `security.md` can't be found, it
+runs what it can from that list and flags the gap — never reports the full checklist as
+passed.
+
+This stage is **repo- and history-scoped, not diff-scoped**: a key committed forty commits
+ago, an unbounded route the diff never touched, or a missing row policy on a table the new
+code now reads are all in scope, because a shallow scan that only reads the diff would
+miss exactly the class of bug that costs the most.
+
+`/security` also runs standalone, outside `/branch-review`; it's the same command, same
+checks, same verify pass — only the report's destination differs (to the orchestrator as
+a stage, to the caller when run directly).
+
+### Stage 3 — Verify (adversarial)
+Findings are claims, not facts. The worker tries to **break** each one, not confirm it — a
+pass that sets out to confirm reliably misses what an adversarial pass finds.
+
+- Re-read the cited `file:line` in full context.
+- `git grep` the name across the repo before trusting any dead-code or unused-symbol claim.
+- Mark each **confirmed**, **false positive** (with the reason), or **uncertain** (with
+  what would settle it).
+
+**Every surviving finding must carry a concrete failure scenario**: specific inputs or
+state → the wrong output, crash, or exposure that results. If the worker can't write that
+sentence, the finding isn't ready — drop it or mark it uncertain. No vibes.
+
+---
+
+## 4. Severity — what blocks, and what doesn't
+
+Only **Critical** and **High** findings block the merge, and only for a **reproduced**
+failure: a failing test, a broken build, a security exposure, or a bug with a written
+failure scenario confirmed in stage 3.
+
+- **Prose and style findings never block.** A finding about a spec's or doc's own
+  wording, structure, or formatting is never a blocker, regardless of severity label.
+- **A finding already dismissed with evidence can't come back at a higher severity
+  without new evidence.** The worker checks this project's stash or memory before
+  escalating something that was already grounded and rejected.
+- Everything below Critical/High — medium and low — never appears in the blocking report.
+  It goes straight to the fix ledger instead (§5).
+
+The report opens with the one-line verdict **before any section**: *Ready to merge? Yes /
+No / Not until these are fixed.* A report that opens with "Critical: none found" reads as
+a pass at a glance even when the verdict isn't one, so the verdict is stated up front and
+repeated at the end. Each blocking finding then carries **Location** (`file:line`),
+**What's wrong**, **Failure scenario**, **Why it matters**, **Suggested fix** (described,
+never applied), and **Verdict** (confirmed / uncertain).
+
+The report closes with a coverage line (stage 1 at level `<level>`, stage 2 full, stage
+3 — each `ran ✓/✗` with its evidence; a stage not actually run is a ✗, never an assumed
+pass), the reviewed SHA and branch and resolved target, tree-clean state, and the ledger
+count.
+
+---
+
+## 5. The fix ledger
+
+`.claude/remember/fix-ledger.md` — a local, persistent, cumulative, non-blocking findings
+list, living beside `MEMORY.md` in `.claude/remember/`. It accumulates across review runs
+and is cleared bullet-by-bullet by `/refactor` (§6). It is not necessarily tracked by
+git: in a repo whose `.gitignore` excludes `.claude/` (as this one's does), the ledger is
+untracked, the same as its neighbours `MEMORY.md`, `AGENT_RULES.md`, and `ledger.json` —
+it persists on disk across sessions regardless of git status. Every medium/low finding
+from a review run lands here as one bullet:
+
+```
+# Fix ledger
+> Non-blocking review findings. One bullet per item. Delete the bullet when
+> fixed, or when its anchor no longer exists. Written by /branch-review;
+> consumed by /refactor (ledger mode).
+
+- `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
+  scenario · YYYY-MM-DD @ <short sha>
+```
+
+**The anchor is a path plus a verbatim snippet — 20–60 characters — never a line number or
+a function name.** A line number rots the moment an unrelated edit shifts the file by one
+line; a function name survives a rename or a merge, or matches the wrong overload. The
+snippet is what `git grep -F` can still find after the surrounding code has moved, and —
+deliberately — it does double duty: the same string that anchors the bullet is also the
+**staleness test**. If `git grep -F` for it comes back empty, the finding's context is
+gone and the bullet is dead weight; if it hits, the finding might still be live and is
+worth a second look. One string serves both jobs instead of the ledger needing a separate
+validity check.
+
+Before appending, `/branch-review` greps the ledger itself for the snippet — a duplicate
+is skipped rather than appended twice.
+
+### One writer per operation
+`/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing
+bullet. `/refactor` in ledger mode **only deletes** — it revalidates and removes bullets as
+their fixes land or their anchors go stale, but it never adds one. Each command has
+exactly one write shape on this file. That split matters because it makes the ledger
+readable as a log: an append is always new evidence from a review, a deletion is always a
+closed or invalidated item, and neither command can silently second-guess what the other
+recorded. If both could edit freely, a bug in either command could corrupt the other's
+half of the record with no way to tell which write did it.
+
+---
+
+## 6. `/refactor` with no arguments — ledger mode
+
+Bare `/refactor` (no code-section argument) works through the ledger instead of taking a
+target from the user:
+
+1. **Tree must be clean and not on `main`.** A dirty tree stops with what's uncommitted;
+   on `main` it switches to `chore/fix-ledger`.
+2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
+3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F "<snippet>"
+   -- <path>`. No hit → delete the bullet, list it as "cleaned by other work" (the anchor
+   is gone, so whatever it pointed at no longer exists in that shape). A hit → re-read the
+   surrounding code; if the finding no longer holds, delete it with a one-line reason.
+   What survives this pass is the actual work list.
+4. **Fix the survivors, one bullet per change**, under `/refactor`'s ordinary constraints
+   (no behavior changes, public API intact, existing tests pass). **Delete each bullet as
+   its fix lands** — the fix commit becomes the done record for that bullet; there's no
+   separate "mark complete" step to forget.
+5. Run the tests, then report fixed / dropped / left, with the reason per left item, and
+   the remaining bullet count.
+6. Say plainly: commit, then run `/branch-review` on this branch — ledger mode is a fixer,
+   not a review, and its own diff gets the ordinary gate like any other change.
+
+---
+
+## 7. The nudge, not the invocation
+
+`/branch-review` ends its report with the open bullet count, and when it's greater than
+zero: *"N fixes waiting — run `/refactor` between features."* **It never invokes
+`/refactor` itself.** This deliberately mirrors `/stash`, which counts the unprocessed
+backlog and nudges `/remember` rather than running it.
+
+The separation exists for the same reason in both places: fixing (like consolidating) is
+its own unit of work with its own review gate — `/refactor`'s diff, once it lands, gets
+reviewed like any other change. Auto-chaining review straight into a fixer would collapse
+"report a finding" and "apply a fix" into one uninterruptible action, removing the human
+decision point about whether, when, and how to fix. A command that only reports stays
+composable with whatever the orchestrator decides to do next; a command that also acts
+on its own report isn't.
+
+---
+
+## 8. Convergence — re-review without re-judging the whole branch
+
+**Re-review after fixes passes the range `<previously-reviewed-sha>..HEAD`.** Stage 1 then
+reads only the fix commits; stage 3 re-verifies the prior report's blockers (fixed /
+unfixed / dismissed, with reason); the rest of the branch is **not** re-judged. The range
+form still ends at HEAD, so `/release`'s precondition is still satisfied.
+
+**The problem this solves:** a full re-read of an already-reviewed branch produces a fresh
+nit list every single run — different findings, or the same findings under new phrasing —
+because a review at this level of judgment is not perfectly deterministic. If `/release`'s
+gate required "zero findings on a full re-review," and every full re-review manufactures
+new low-severity nits, the branch would never converge: HEAD keeps moving (each round of
+fixes is itself a commit), and each new HEAD invites another full read that finds
+something new to flag. Scoping re-review to just the delta since the last reviewed SHA
+means the parts of the branch that were already read and judged aren't read and judged
+again — only the actual fix commits are, plus a check that the previously-raised blockers
+are actually gone. That's what lets the loop terminate instead of running forever.
+
+---
+
+## 9. How `/release` Phase 0.5 fits
+
+`/release` refuses to run past its own Phase 0.5 without a review at the *current* HEAD
+SHA. It does not ask the orchestrator whether a review happened — asking puts the question
+to the one party with an incentive to say yes. Instead it runs `git rev-parse HEAD` and
+compares that string, mechanically, against the SHA `/branch-review` recorded in its
+closing line (`Reviewed at HEAD <sha>`). **The SHA comparison is the gate** — it is what
+makes "this branch was reviewed" a checked fact instead of a claim, independent of
+whatever state the ledger file happens to be in.
+
+- **No recorded SHA at all** → no review, full stop: *"No review at `<sha>`. Run
+  `/branch-review medium` (or `/code-review medium`) first."*
+- **Recorded SHA ≠ current HEAD** (commits landed after the review, including fix
+  commits) → **stale**, stop and ask for a re-review.
+- **A carve-out applies in a repo where the ledger happens to be tracked by git**: if
+  `git diff --name-only <recorded-sha>..HEAD` prints exactly
+  `.claude/remember/fix-ledger.md` and nothing else, the review still stands — the ledger
+  is the review's own output, and appending to it doesn't change any reviewed code. In a
+  repo where `.claude/` is gitignored (as here), the ledger never appears in a commit
+  diff at all, so this carve-out simply never fires there — every commit after the review
+  is judged purely on whether it touches tracked files, and an untracked ledger append
+  can't be the thing that makes a diff non-empty in the first place. Any other tracked
+  path in that diff means stale.
+- **Reviewed at this SHA with findings still outstanding** → stop; findings are resolved
+  before a release is cut.
+
+This is the only thing guaranteeing the branch was reviewed *and* security-scanned before
+release, so a missing answer is always treated as a stop, never as a pass.
+
+---
+
+## 10. Worked example — two features through the full loop
+
+**Feature A lands.**
+1. Work is committed to `feat/a`. `/branch-review` runs with a clean tree, resolves the
+   empty-argument target to `main..HEAD`, and records `HEAD abc123`.
+2. Stage 1 finds one High (a null path with a written failure scenario) and three
+   low-severity nits. Stage 2 runs full and comes back clean. Stage 3 confirms the High
+   and drops one of the three nits as a false positive.
+3. Report: **Ready to merge? Not until these are fixed** — the High blocks. The two
+   surviving low findings are appended to `fix-ledger.md`. Ledger: 2 open, 2 added.
+4. The High is fixed by hand (or by a targeted `/refactor <file>`), committed, and
+   `/branch-review abc123..HEAD` re-reviews just that fix commit. Stage 3 confirms the
+   prior High is now fixed. Recorded SHA moves to `def456`.
+5. `/release` runs. Phase 0.5 compares `def456` to `HEAD` — match — and finds no findings
+   outstanding at that SHA. It proceeds through `/ship`, docs, version bump, and stops with
+   the push/PR/merge/tag/publish sequence for a human to authorize.
+
+**Feature B lands later, on top of the merged A.**
+1. `feat/b` is committed. `/branch-review` (empty target) resolves against the new
+   merge-base and reviews only B's diff — A's history isn't re-read, because it was
+   already reviewed and merged.
+2. Stage 1 finds nothing blocking, but two more low-severity findings. Ledger now has
+   2 (carried, unrelated to A or B) + 2 new = 4 open. Report ends: *"4 fixes waiting — run
+   `/refactor` between features."*
+3. Before starting a third feature, `/refactor` (no arguments) runs: tree is clean, not on
+   main, so it switches to `chore/fix-ledger`. It revalidates all 4 bullets — one anchor no
+   longer greps (cleaned by an unrelated change), one no longer holds on re-read, two
+   survive and get fixed one at a time, each deleting its own bullet as it lands.
+4. The fix commit is reported (2 fixed, 2 dropped, 0 left), then `/branch-review` reviews
+   the `chore/fix-ledger` branch like any ordinary change before it merges.
+
+---
+
+## Sources
+
+`packages/claude/commands/branch-review.md` (the command spec — target resolution, the
+three stages, severity rules, ledger format, report shape), `packages/claude/commands/
+refactor.md` (ledger mode), `packages/claude/commands/release.md` (Phase 0.5, the
+ledger-only carve-out), `packages/claude/commands/security.md` (stage 2 delegation),
+`packages/claude/commands/stash.md` (the nudge pattern `/branch-review`'s own nudge
+mirrors).

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -327,6 +327,10 @@ is the orchestrator's word, which this gate exists precisely not to take.
 makes "this branch was reviewed" a checked fact instead of a claim, independent of
 whatever state the ledger file happens to be in.
 
+- **`verdict: blocked`** → stop, even on a matching SHA. The hash proves a review ran at
+  this commit; the verdict is what it concluded, and only `ready` plus a matching hash is a
+  pass. Both lines are read mechanically, for the same reason: the alternative is trusting
+  someone's memory of the outcome.
 - **No record file, or no `sha:` line in it** → no review, full stop: *"No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."*
 - **Recorded SHA ≠ current HEAD** (commits landed after the review, including fix

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -214,6 +214,36 @@ from a review run lands here as one bullet:
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
+### The review record
+
+`.claude/remember/last-review.md`, written at the end of every run and overwritten whole:
+
+```
+sha: <full HEAD sha>
+branch: <branch>
+target: <resolved range or path>
+level: <low | medium | high | max>
+verdict: <ready | blocked>
+date: <YYYY-MM-DD>
+coverage: stage1 ran, stage2 ran, stage3 ran
+blockers:
+- <file:line> · <one-sentence claim>
+```
+
+It answers one question — was *this commit* reviewed, and what came of it — so only the
+latest answer can be true, which is why it is overwritten rather than appended. The
+blockers list exists so a session that never saw the report can act on a `blocked` verdict
+instead of re-reviewing the branch to rediscover why, and it carries claims only: scenarios
+and fixes stay in the report, non-blocking findings stay in the ledger.
+
+**Nothing clears it.** The `sha:` line expires it: commit a fix and the recorded hash stops
+matching HEAD, so the gate reports *stale* and asks for a re-review rather than *blocked*.
+A blocked verdict persists only while HEAD does not move, meaning nothing was fixed. There
+is no override field either — a hash is checkable by anyone and consent is not, so a
+consent line would be forgeable by whatever writes the file, and a persisted override would
+silently cover the next release too. Releasing over a blocked review is a live decision at
+`/release`'s hand-back.
+
 **The anchor is a path plus a verbatim snippet — 20–60 characters — never a line number or
 a function name.** A line number rots the moment an unrelated edit shifts the file by one
 line; a function name survives a rename or a merge, or matches the wrong overload. The

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -382,7 +382,7 @@ are actually gone. That's what lets the loop terminate instead of running foreve
 SHA. It does not ask the orchestrator whether a review happened — asking puts the question
 to the one party with an incentive to say yes. Instead it runs `git rev-parse HEAD` and
 compares that string, mechanically, against the `sha:` line in
-`.claude/remember/last-review.md`, the five-line record `/branch-review` overwrites at the
+`.claude/remember/last-review.md`, the record `/branch-review` overwrites at the
 end of every run. That record exists because a SHA quoted in a chat message is the same
 claim in another costume: it does not survive a compaction or a handover, and what remains
 is the orchestrator's word, which this gate exists precisely not to take.

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -165,7 +165,11 @@ failure scenario confirmed in stage 3.
   without new evidence.** The worker checks this project's stash or memory before
   escalating something that was already grounded and rejected.
 - Everything below Critical/High — medium and low — never appears in the blocking report.
-  It goes straight to the fix ledger instead (§5).
+  It goes straight to the fix ledger instead (§5). "Style, wording or structure" is
+  the actual exemption, not "prose": where the deliverable *is* a specification, a
+  normative requirement stated two incompatible ways is a reproduced defect, because
+  two conforming implementations built from it diverge. The test is whether a
+  behaviour changes, not whether the file holds code.
 
 The report opens with the one-line verdict **before any section**: *Ready to merge? Yes /
 No / Not until these are fixed.* A report that opens with "Critical: none found" reads as
@@ -213,6 +217,13 @@ deliberately — it does double duty: the same string that anchors the bullet is
 gone and the bullet is dead weight; if it hits, the finding might still be live and is
 worth a second look. One string serves both jobs instead of the ledger needing a separate
 validity check.
+
+A bullet's failure scenario is subject to stage 3 like any other finding. Ledger items
+skip the report, which makes them easy to skip verifying, and an unverified consequence
+written in the bullet's voice reads as established fact to whoever fixes it later — a
+real field run produced exactly that, a true finding whose stated consequence was false.
+Either confirm the scenario or prefix it with `UNVERIFIED:`, which tells `/refactor` to
+retest before acting.
 
 Before appending, `/branch-review` greps the ledger itself for the snippet — a duplicate
 is skipped rather than appended twice. That one grep must be plain `grep -F`, never `git
@@ -299,13 +310,17 @@ are actually gone. That's what lets the loop terminate instead of running foreve
 `/release` refuses to run past its own Phase 0.5 without a review at the *current* HEAD
 SHA. It does not ask the orchestrator whether a review happened — asking puts the question
 to the one party with an incentive to say yes. Instead it runs `git rev-parse HEAD` and
-compares that string, mechanically, against the SHA `/branch-review` recorded in its
-closing line (`Reviewed at HEAD <sha>`). **The SHA comparison is the gate** — it is what
+compares that string, mechanically, against the `sha:` line in
+`.claude/remember/last-review.md`, the five-line record `/branch-review` overwrites at the
+end of every run. That record exists because a SHA quoted in a chat message is the same
+claim in another costume: it does not survive a compaction or a handover, and what remains
+is the orchestrator's word, which this gate exists precisely not to take.
+**The SHA comparison is the gate** — it is what
 makes "this branch was reviewed" a checked fact instead of a claim, independent of
 whatever state the ledger file happens to be in.
 
-- **No recorded SHA at all** → no review, full stop: *"No review at `<sha>`. Run
-  `/branch-review medium` (or `/code-review medium`) first."*
+- **No record file, or no `sha:` line in it** → no review, full stop: *"No review at
+  `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."*
 - **Recorded SHA ≠ current HEAD** (commits landed after the review, including fix
   commits) → **stale**, stop and ask for a re-review.
 - **The fix ledger is not an exception.** Where `.claude/` is gitignored (as here), an

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -242,7 +242,9 @@ pass on every run. The anchor lookups against source files above are `git grep`,
 `/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing
 bullet. `/refactor` in ledger mode **only deletes** — it revalidates and removes bullets as
 their fixes land or their anchors go stale, but it never adds one. Each command has
-exactly one write shape on this file. That split matters because it makes the ledger
+exactly one write shape on this file, and no third command has any — `/release`'s docs
+sweep may well correct a line a bullet names, since that doc changed with the feature, but
+it leaves the bullet alone and the next revalidation drops it. That split matters because it makes the ledger
 readable as a log: an append is always new evidence from a review, a deletion is always a
 closed or invalidated item, and neither command can silently second-guess what the other
 recorded. If both could edit freely, a bug in either command could corrupt the other's

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -196,6 +196,9 @@ from a review run lands here as one bullet:
 > Non-blocking review findings. One bullet per item. Delete the bullet when
 > fixed, or when its anchor no longer exists. Written by /branch-review;
 > consumed by /refactor (ledger mode).
+>
+> A bullet's path may be a glob when the same finding exists in every kit —
+> `git grep -F "<snippet>" -- <path>` accepts one.
 
 - `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
   scenario · YYYY-MM-DD @ <short sha>
@@ -212,7 +215,11 @@ worth a second look. One string serves both jobs instead of the ledger needing a
 validity check.
 
 Before appending, `/branch-review` greps the ledger itself for the snippet — a duplicate
-is skipped rather than appended twice.
+is skipped rather than appended twice. That one grep must be plain `grep -F`, never `git
+grep`: `git grep` searches tracked content only, and the ledger is normally gitignored, so
+it would answer "not found" for a snippet that is present and the dedupe would silently
+pass on every run. The anchor lookups against source files above are `git grep`, correctly
+— those files are tracked. Same flag, two different targets, only one of them in git.
 
 ### One writer per operation
 `/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -301,15 +301,12 @@ whatever state the ledger file happens to be in.
   `/branch-review medium` (or `/code-review medium`) first."*
 - **Recorded SHA ≠ current HEAD** (commits landed after the review, including fix
   commits) → **stale**, stop and ask for a re-review.
-- **A carve-out applies in a repo where the ledger happens to be tracked by git**: if
-  `git diff --name-only <recorded-sha>..HEAD` prints exactly
-  `.claude/remember/fix-ledger.md` and nothing else, the review still stands — the ledger
-  is the review's own output, and appending to it doesn't change any reviewed code. In a
-  repo where `.claude/` is gitignored (as here), the ledger never appears in a commit
-  diff at all, so this carve-out simply never fires there — every commit after the review
-  is judged purely on whether it touches tracked files, and an untracked ledger append
-  can't be the thing that makes a diff non-empty in the first place. Any other tracked
-  path in that diff means stale.
+- **The fix ledger is not an exception.** Where `.claude/` is gitignored (as here), an
+  append never reaches a commit, HEAD does not move, and the recorded SHA still matches —
+  so the question never arises. A repo that tracks `.claude/` instead will see a ledger
+  commit land after the review and make it stale. That is the gate working as designed,
+  not a case to special-case: re-review, or leave the ledger uncommitted until the
+  release is cut. One rule, no branches in it.
 - **Reviewed at this SHA with findings still outstanding** → stop; findings are resolved
   before a release is cut.
 
@@ -356,6 +353,6 @@ release, so a missing answer is always treated as a stop, never as a pass.
 `packages/claude/commands/branch-review.md` (the command spec — target resolution, the
 three stages, severity rules, ledger format, report shape), `packages/claude/commands/
 refactor.md` (ledger mode), `packages/claude/commands/release.md` (Phase 0.5, the
-ledger-only carve-out), `packages/claude/commands/security.md` (stage 2 delegation),
+SHA gate), `packages/claude/commands/security.md` (stage 2 delegation),
 `packages/claude/commands/stash.md` (the nudge pattern `/branch-review`'s own nudge
 mirrors).

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -226,6 +226,12 @@ from a review run lands here as one bullet:
 
 ---
 
+**Disproving a bullet deletes it.** The append-only rule stops a reviewer rewriting
+history, not from correcting the record: if you establish a bullet's finding no longer
+holds, the line goes and the reason goes in the report. The ledger is a work list, not an
+archive — an annotated bullet still reads as work, and a bullet arguing with itself is
+worse than none.
+
 ### One writer per operation
 `/branch-review` **only appends** to the ledger; it never rewrites or deletes an existing
 bullet. `/refactor` in ledger mode **only deletes** — it revalidates and removes bullets as
@@ -262,6 +268,10 @@ latest answer can be true, which is why it is overwritten rather than appended. 
 blockers list exists so a session that never saw the report can act on a `blocked` verdict
 instead of re-reviewing the branch to rediscover why, and it carries claims only: scenarios
 and fixes stay in the report, non-blocking findings stay in the ledger.
+
+**A run that produces no record is not a review.** A review that dies mid-flight — rate
+limit, crash, cancelled turn — writes nothing, and the gate treats a missing record as no
+review. Silence is never a pass.
 
 **Nothing clears it.** The `sha:` line expires it: commit a fix and the recorded hash stops
 matching HEAD, so the gate reports *stale* and asks for a re-review rather than *blocked*.

--- a/docs/product/remember-README.md
+++ b/docs/product/remember-README.md
@@ -477,3 +477,47 @@ cat .claude/remember/friction/antigen_clusters.json
 # human-readable:
 cat .claude/remember/friction/antigen_review.md
 ```
+
+## 6. Known limitations
+
+These are structural, not bugs on a backlog. Each one is a place where closing the
+gap costs more than the gap does — recorded here so the next person does not spend a
+session rediscovering that.
+
+### Matching semantics and evidence are the same channel
+
+A ledger entry's `class_hints` **are** fragments of the quotes that proved it. `ag-001`
+carries `"did you ground your check"` and `"fucking validate this after correction"`.
+Step 4a then hands the classifier `class_hints` + `rule` + `evidence.quotes` and asks
+whether a new cluster is that same mistake class. So an entry's *identity* — what
+distinguishes it from every other entry — is made of the same strings as its *evidence*
+that the mistake recurs. The two are coupled by construction.
+
+Two consequences follow, and they pull in opposite directions:
+
+- **Tautological matching.** A cluster can match an entry on the strength of the very
+  quotes that seeded it, which is a match against itself rather than against a new
+  occurrence. Session-hash dedup neutralises the common case — the same session cannot
+  be counted twice — but the identity is per session, not per quote, so it bounds the
+  damage rather than removing the cause.
+- **Over-matching on thin ledgers.** Where `class_hints` are short generic phrases,
+  they match ordinary frustration that shares a word. This is `Open item 2` in
+  `remember.md`, and it is why 4a requires a negative example ("`we're burning money,
+  why is it failing?` does NOT match") rather than the positive claim alone.
+
+Decoupling either way makes the other worse. Narrow matching to the `rule` and genuine
+recurrence phrased differently stops counting — recall gaps are the failure this
+pipeline exists to avoid. Widen it back onto the quotes and generic entries swallow
+unrelated clusters, which is the failure precision was chosen over recall to prevent.
+The negative-example requirement is the mitigation; there is no fix that is not a trade.
+
+### A run cannot tell that its own work invalidated a standing fact
+
+`/remember` writes facts from stashes and friction output. It has no way to notice that
+work done *in the same session* has just falsified a fact already in `MEMORY.md` — a
+fact asserting two files stay tracked survives a commit, in that same session, that
+gitignores them. Detecting this would mean re-checking every standing fact against the
+working tree on every run, and rewriting facts on that evidence is worse than leaving a
+stale one: the heuristic would be confidently wrong about facts it half-understood.
+Stale facts are corrected the way they were written — by a human noticing, or by the
+next run's extraction contradicting them outright.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "AI development toolkit with 11 specialized agents and 18 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -200,6 +200,9 @@ missing):
 > Non-blocking review findings. One bullet per item. Delete the bullet when
 > fixed, or when its anchor no longer exists. Written by /branch-review;
 > consumed by /refactor (ledger mode).
+>
+> A bullet's path may be a glob when the same finding exists in every kit —
+> `git grep -F "<snippet>" -- <path>` accepts one.
 
 - `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
   scenario · YYYY-MM-DD @ <short sha>
@@ -208,8 +211,12 @@ missing):
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
-appending, `git grep -F` the snippet in the ledger itself; if it is already
-there, skip it. Do not touch existing bullets.
+appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
+if it is already there, skip it. Do not touch existing bullets. Use plain
+`grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
+and `git grep` searches tracked content only, so it reports "not found" for a
+snippet that is sitting right there — the dedupe would pass every time and
+the same finding would be appended on every run.
 
 Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
 **Failure scenario** (inputs/state → result) · **Why it matters** ·

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -257,7 +257,15 @@ The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
 appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
-if it is already there, skip it. Do not touch existing bullets. Use plain
+if it is already there, skip it. Do not touch existing bullets.
+
+**A bullet you disprove is deleted, not annotated.** If you establish that an
+existing bullet's finding no longer holds — or never did — remove the line and
+say why in your report. The ledger is a work list, not an archive: an
+annotated bullet still reads as work, and a bullet arguing with itself is
+worse than none. Deleting on disproof is the one case where a reviewer may
+remove a line, and it is the same judgement `/refactor` makes at
+revalidation. Use plain
 `grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
 and `git grep` searches tracked content only, so it reports "not found" for a
 snippet that is sitting right there — the dedupe would pass every time and
@@ -325,5 +333,10 @@ End with:
   local artifact; in the usual case it is gitignored, so writing it moves
   nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
+- **A run that produces no record is not a review.** If you die mid-flight —
+  a rate limit, a crash, a cancelled turn — there is no report and no
+  `last-review.md`, and silence must never be read as a pass. `/release`
+  already treats a missing record as no review; state it here too so nobody
+  fills the gap from memory of a run that never finished.
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -46,12 +46,24 @@ at the current HEAD SHA.
   even for a finding you are certain about. Report it. The only files you may
   write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
   delete) and `.claude/remember/last-review.md` (overwrite; the review record
-  described at the end of this file). Re-run `git status --porcelain` before
-  you report: it must be empty or list only those paths — anything else, say
-  what changed. That turns "it never edits" from a claim into a checked
-  fact.
+  described at the end of this file).
+- **Prove it with two checks, because neither sees what the other does.**
+  `git status --porcelain`, at start and again before you report, proves no
+  **tracked** file changed — that is the "never edits code" guarantee, and it
+  is the one that matters. It cannot police your own two writes: `.claude/`
+  is normally gitignored, so porcelain stays empty whether you wrote the
+  allowed files, wrote nothing, or overwrote `MEMORY.md`. `git status
+  --ignored` does not close it either — it collapses to `!! .claude/`, the
+  directory, not the files. So also take `md5sum .claude/remember/*` before
+  you start and again before you report, and show the comparison: only
+  `fix-ledger.md` and `last-review.md` may differ.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
+
+**The orchestrator runs this check before spawning anyone**, so a dirty tree
+costs no worker; the worker then re-runs it as its own first act, because a
+review that takes the tree's state on trust is the thing this command exists
+not to do. Both, not either.
 
 **Before resolving anything, run `git status --porcelain`.** If it prints any
 line — modified, staged, or untracked — **stop and report it**. Say all three
@@ -201,7 +213,8 @@ including in a doc or spec. But prose is not automatically harmless: in a repo
 whose deliverable *is* a specification, a **normative requirement stated two
 incompatible ways** is a reproduced defect, because two conforming
 implementations built from it diverge. Judge by whether a behaviour changes,
-not by whether the file holds code. A finding already dismissed with evidence in this project's stash
+not by whether the file holds code — and judge it **per finding, not per
+repo**, since a diff mixing code and specification is the normal case. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -11,9 +11,11 @@ reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
 Only **Critical** and **High** findings block the merge. Everything else is
-appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
-committed, cumulative list that `/refactor` (no arguments) works through
-between features. The report is blockers plus the ledger count, so a review
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a local,
+cumulative list, living beside `MEMORY.md`, that `/refactor` (no arguments)
+works through between features. Like its neighbours it is a private working
+artifact, usually gitignored; it persists across reviews, it is not a
+deliverable. The report is blockers plus the ledger count, so a review
 converges instead of surfacing fresh nits every run. This command never runs
 `/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
 
@@ -222,8 +224,9 @@ End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
   tree clean at start; at exit clean or `fix-ledger.md` only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
-  add: "N fixes waiting — run `/refactor` between features." The orchestrator
-  commits the ledger; `/release` accepts a ledger-only commit after the review.
+  add: "N fixes waiting — run `/refactor` between features." The ledger is a
+  local artifact; in the usual case it is gitignored, so writing it moves
+  nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -104,6 +104,14 @@ its exit code.
   "temporary" names, abandoned feature flags.
 - **Correctness.** Edge cases, error handling, type / contract violations,
   broken invariants.
+- **State ownership.** Two or more functions assigning the same field, flag, or
+  view property. A finding on its own — no failing case required. `git grep`
+  every assignment to that name repo-wide, not just in the diff; the second
+  writer is usually in a file the diff never touched. Name both writers with
+  `file:line` — an unnamed second writer is a hunch, not a finding. Count
+  ordering, not just writers: a write arriving from a callback, thread, or
+  lifecycle event is the dangerous one, and one app writer racing a framework
+  one still counts as two.
 - **Performance.** N+1, blocking calls in hot paths, unbounded loops, indexes
   the diff actually touches.
 - **Test quality, not just test presence.** For every test the diff adds or

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -95,12 +95,23 @@ Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
 
-**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
-Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
-blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
-**not** re-judged. A full re-read of an already-reviewed branch produces fresh
-findings every time and never converges. The range form still ends at HEAD,
-so `/release`'s precondition is satisfied.
+**Re-review after fixes: read `.claude/remember/last-review.md` first.** Its
+`sha:` line is the previously-reviewed commit and its `blockers:` list is what
+you owe an answer on — take both from the file, never from the orchestrator's
+recollection, for the same reason `/release` does. Then:
+
+- **`sha:` ≠ HEAD** → this is a re-review. Target the range
+  `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
+  re-verifies each recorded blocker as fixed, unfixed, or dismissed with a
+  reason. The rest of the branch is **not** re-judged: a full re-read of an
+  already-reviewed branch produces fresh findings every run and never
+  converges. The range still ends at HEAD, so `/release`'s precondition is
+  satisfied and the new record replaces the old one.
+- **`sha:` = HEAD** → nothing has changed since the last review. Say so and
+  stop; re-running against an identical tree can only produce noise. If the
+  recorded verdict was `blocked`, its blockers are still unfixed by
+  definition — repeat them rather than re-deriving them.
+- **No file** → no prior review to build on. Review the whole branch.
 
 **On a re-review, sweep the open ledger bullets for liveness first.** Their
 anchors may sit in the part of the branch you are no longer reading, and the

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -42,12 +42,14 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits — one exception.** You have no authorization to change code,
-  even for a finding you are certain about. Report it. The **only** file you
-  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
-  or delete). Re-run `git status --porcelain` before you report: it must be
-  empty or list exactly that one path — anything else, say what changed. That
-  turns "it never edits" from a claim into a checked fact.
+- **No edits — two exceptions.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The only files you may
+  write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
+  delete) and `.claude/remember/last-review.md` (overwrite; the review record
+  described at the end of this file). Re-run `git status --porcelain` before
+  you report: it must be empty or list only those paths — anything else, say
+  what changed. That turns "it never edits" from a claim into a checked
+  fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
 
@@ -87,6 +89,12 @@ blockers (fixed / unfixed / dismissed — with reason); the rest of the branch i
 **not** re-judged. A full re-read of an already-reviewed branch produces fresh
 findings every time and never converges. The range form still ends at HEAD,
 so `/release`'s precondition is satisfied.
+
+**On a re-review, sweep the open ledger bullets for liveness first.** Their
+anchors may sit in the part of the branch you are no longer reading, and the
+fix commits you *are* reading can invalidate them. `grep -F` each open
+snippet against its path; report any whose anchor is gone so `/refactor` can
+drop them. Cheap, and it stops dead bullets accumulating unseen.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -185,8 +193,12 @@ Then the findings, ordered most severe first.
 ### 🚨 Critical / High (blocks merge)
 A **reproduced** failure only: a failing test, a broken build, a security
 exposure, or a bug with a written failure scenario you confirmed in stage 3.
-A finding about a spec's or doc's own prose, structure, or style is **never**
-a blocker. A finding already dismissed with evidence in this project's stash
+A finding about **style, wording or structure** is **never** a blocker —
+including in a doc or spec. But prose is not automatically harmless: in a repo
+whose deliverable *is* a specification, a **normative requirement stated two
+incompatible ways** is a reproduced defect, because two conforming
+implementations built from it diverge. Judge by whether a behaviour changes,
+not by whether the file holds code. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 
@@ -208,6 +220,12 @@ missing):
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
+**A ledger bullet's failure scenario is subject to stage 3 like any other.**
+Ledger items skip the report, so they are easy to skip verifying too, and an
+unverified consequence written in the bullet's voice reads as established
+fact to whoever fixes it later. Either confirm it, or prefix the scenario
+with `UNVERIFIED:` so `/refactor` retests before acting.
+
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
@@ -227,9 +245,24 @@ Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
 each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
+**Write the review record** to `.claude/remember/last-review.md`, overwriting
+it. `/release` reads this file; a SHA that lives only in a chat message is
+gone after a compaction or a handover, and the only remaining source is the
+orchestrator — the one party this command already refuses to take a review's
+word from. Exactly these five lines:
+
+```
+sha: <full HEAD sha>
+branch: <branch>
+target: <resolved range or path>
+verdict: <ready | blocked>
+date: <YYYY-MM-DD>
+```
+
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start; at exit clean or `fix-ledger.md` only.**
+  tree clean at start; at exit clean or the two `.claude/remember/` paths
+  only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
   add: "N fixes waiting — run `/refactor` between features." The ledger is a
   local artifact; in the usual case it is gitignored, so writing it moves

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -265,15 +265,45 @@ assumed pass.
 it. `/release` reads this file; a SHA that lives only in a chat message is
 gone after a compaction or a handover, and the only remaining source is the
 orchestrator — the one party this command already refuses to take a review's
-word from. Exactly these five lines:
+word from. **Write it at the end of every run, unconditionally** — not after
+someone decides what to do about it. The information exists now, and the file
+earns its keep only by surviving a compaction, an abandoned session, or a
+handover to someone who never saw the report.
 
 ```
 sha: <full HEAD sha>
 branch: <branch>
 target: <resolved range or path>
+level: <low | medium | high | max>
 verdict: <ready | blocked>
 date: <YYYY-MM-DD>
+coverage: stage1 <ran|NOT RUN>, stage2 <ran|NOT RUN>, stage3 <ran|NOT RUN>
+blockers:
+- <file:line> · <one-sentence claim, no scenario, no suggested fix>
 ```
+
+`blockers: none` when the verdict is ready. One line per blocker and nothing
+more: the reasoning belongs in the report, and the non-blocking findings
+belong in the ledger. This exists so a session that never saw the report can
+learn *what* is blocked, not just *that* something is — otherwise the next
+run rediscovers it by re-reviewing the branch, which is the
+non-convergence this command exists to stop.
+
+`coverage` is recorded because a `ready` from a run whose security stage did
+not execute is not the same fact as one where it did, and the reader of this
+file cannot tell them apart otherwise.
+
+**There is no override field, and no `verdict: overridden`.** A SHA is
+checkable by anyone; consent is not, so a consent line in a file is forgeable
+by whatever writes the file — and a persisted override is reusable, silently
+covering the next release as well as this one. Releasing over a blocked
+review is a live decision made at `/release`'s hand-back, in conversation.
+
+**Nothing clears this file.** It is overwritten whole on the next run, and the
+`sha:` line is what expires it: fix something, commit, and the recorded hash
+no longer matches HEAD, so the gate reports *stale* and asks for a
+re-review rather than *blocked*. A blocked verdict can only persist while HEAD
+does not move — which means nothing was fixed, which is the correct outcome.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -118,7 +118,10 @@ judging.
 not a fact to accept. Branches are commonly AI-authored now — including the
 fixes to the fixes — so a review that trusts the message is reviewing prose.
 Run the test suite and the typecheck/build yourself and cite the command and
-its exit code.
+its exit code. Read that code off the bare command (`cmd > /tmp/out 2>&1;
+e=$?`), never off a pipeline — `$?` after a pipe is the last element's
+status, so piping into `tail` reports `0` for a suite that failed. `/ship`
+carries the reproduction.
 
 - **Bugs needing a fix.** Logic errors, off-by-one, null/undefined paths,
   races, wrong defaults, broken edge cases.

--- a/packages/ampcode/commands/branch-review.md
+++ b/packages/ampcode/commands/branch-review.md
@@ -10,6 +10,13 @@ audit** — followed by an adversarial verify pass. It **never edits code**: it
 reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
+Only **Critical** and **High** findings block the merge. Everything else is
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
+committed, cumulative list that `/refactor` (no arguments) works through
+between features. The report is blockers plus the ledger count, so a review
+converges instead of surfacing fresh nits every run. This command never runs
+`/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
+
 Run this **before** `/release`. `/release` will refuse to run without a review
 at the current HEAD SHA.
 
@@ -33,9 +40,11 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits.** You have no authorization to change code, even for a finding
-  you are certain about. Report it. Re-run `git status --porcelain` before you
-  report and confirm it is still empty — if it is not, say what changed. That
+- **No edits — one exception.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The **only** file you
+  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
+  or delete). Re-run `git status --porcelain` before you report: it must be
+  empty or list exactly that one path — anything else, say what changed. That
   turns "it never edits" from a claim into a checked fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
@@ -69,6 +78,13 @@ With a clean tree, interpret `$ARGUMENTS` in this order:
 Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
+
+**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
+Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
+blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
+**not** re-judged. A full re-read of an already-reviewed branch produces fresh
+findings every time and never converges. The range form still ends at HEAD,
+so `/release`'s precondition is satisfied.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -164,21 +180,50 @@ verdict first, then repeat it at the end.
 
 Then the findings, ordered most severe first.
 
-### 🚨 Critical (blocks merge)
-### ⚠️ Warnings (should fix)
-### 💡 Suggestions (nice to have)
+### 🚨 Critical / High (blocks merge)
+A **reproduced** failure only: a failing test, a broken build, a security
+exposure, or a bug with a written failure scenario you confirmed in stage 3.
+A finding about a spec's or doc's own prose, structure, or style is **never**
+a blocker. A finding already dismissed with evidence in this project's stash
+or memory cannot come back at a higher severity without **new** evidence —
+check before escalating.
 
-Each finding: **Location** (`file:line`) · **What's wrong** · **Failure
-scenario** (inputs/state → result) · **Why it matters** · **Suggested fix**
-(described, not applied) · **Verdict** (confirmed / uncertain).
+### Ledger (non-blocking — medium / low)
+Not in the report. **Append** each one as a single bullet to
+`.claude/remember/fix-ledger.md` (create the file with the header below if
+missing):
 
-Then a coverage line: stage 1 at level `<level>`, stage 2 full — each `ran ✓/✗`
-with its evidence. A stage you did not actually run is a **✗**, never an
+```
+# Fix ledger
+> Non-blocking review findings. One bullet per item. Delete the bullet when
+> fixed, or when its anchor no longer exists. Written by /branch-review;
+> consumed by /refactor (ledger mode).
+
+- `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
+  scenario · YYYY-MM-DD @ <short sha>
+```
+
+The **snippet is the anchor**: 20–60 verbatim characters from the line,
+unique enough for `git grep -F` to find it after lines shift. No line
+numbers, no TODO comments in code — the ledger is the single writer. Before
+appending, `git grep -F` the snippet in the ledger itself; if it is already
+there, skip it. Do not touch existing bullets.
+
+Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
+**Failure scenario** (inputs/state → result) · **Why it matters** ·
+**Suggested fix** (described, not applied) · **Verdict** (confirmed /
+uncertain).
+
+Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
+each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start and at exit.**
+  tree clean at start; at exit clean or `fix-ledger.md` only.**
+- **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
+  add: "N fixes waiting — run `/refactor` between features." The orchestrator
+  commits the ledger; `/release` accepts a ledger-only commit after the review.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/ampcode/commands/refactor.md
+++ b/packages/ampcode/commands/refactor.md
@@ -57,7 +57,9 @@ Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 verification, HITL gates) still applies; this section only says what to
 refactor and how to close each item.
 
-1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+1. **Tree must be clean and not on `main`.** The orchestrator runs this check
+   before spawning the worker, so a dirty tree costs no worker; the worker
+   then re-runs it as its own first act. `git status --porcelain` non-empty
    → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
 2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
 3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F

--- a/packages/ampcode/commands/refactor.md
+++ b/packages/ampcode/commands/refactor.md
@@ -7,6 +7,50 @@ allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(
 ---
 Refactor $ARGUMENTS.
 
+## Guardrails
+- **Spawn a worker and explicitly select your tool's mid tier.** State the
+  tier on the spawn — do not omit it and rely on a default. An omitted tier
+  inherits the *parent's* tier, which is not the same thing as the balanced
+  one. Pick the judgment-capable tier that is cheaper and faster than your top
+  reasoning tier. **Not the cheapest/fastest tier**: on judgment work it
+  measurably degrades (misclassification rates several times higher). Choose by
+  tier, not by a vendor model name copied from this file — names drift, and
+  this command ships to several tools. Fall back to running inline if your tool
+  has no subagent mechanism.
+- **Escalate, never assume.** Anything you cannot decide, cannot verify, or
+  that this spec does not cover → **stop and report it to the orchestrator**
+  (the main session). Never improvise, never widen scope, never fix a side
+  issue you noticed along the way.
+- **The worker does the work itself — no delegation.** The fixer must **not**
+  spawn subagents of its own. Every edit it reports, and every test run it
+  cites, has to be one it made or ran with its own tool calls: a relayed "I
+  fixed it and the suite is green" from a sub-worker is hearsay, and this
+  command's whole output is the claim that a change landed and the tests still
+  pass. A fix that delegates its work is a report about a report.
+- **The HITL gates below belong to the orchestrator, not the worker.** A
+  subagent cannot hold a conversation with the user, so it cannot run a gate
+  that ends in *stop and ask*. When one trips — a failing test, a crossed
+  public API boundary, a change bigger than the bullet asked for — the worker
+  **stops there and hands the situation back**, with the options and its
+  reasoning but no choice made. The orchestrator asks. A worker that picks
+  revert / patch / update-test on the user's behalf has answered a question it
+  was never allowed to ask.
+- **Edit only what a surviving bullet names.** Ledger mode's scope is the
+  bullets that survive revalidation, one change per bullet — not the
+  neighbouring code, not the formatting, not a second finding noticed on the
+  way past. Anything else goes back to the orchestrator to become a new
+  bullet.
+- **Prove the blast radius with two checks, because neither sees what the
+  other does.** `git status --porcelain` at exit must list only files a
+  surviving bullet named — that is this command's scope guarantee, and unlike
+  `/branch-review` it is not expected to be empty. It cannot police the
+  memory directory: `.claude/` is normally gitignored, so porcelain stays
+  empty whether you deleted a fixed bullet, wrote nothing, or overwrote
+  `MEMORY.md`. So also take `md5sum .claude/remember/*` before you start and
+  again before you report, and show the comparison: only `fix-ledger.md` may
+  differ. `last-review.md` in particular is `/branch-review`'s to write —
+  a fixer that touches it forges the gate that judges its own work.
+
 ## Ledger mode — `$ARGUMENTS` empty
 Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 `/branch-review` has accumulated. Everything below (goals, constraints,

--- a/packages/ampcode/commands/refactor.md
+++ b/packages/ampcode/commands/refactor.md
@@ -1,11 +1,33 @@
 ---
 name: refactor
 description: Refactor [code]
-usage: /refactor <code-section>
-argument-hint: [file-or-function]
-allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *)
+usage: /refactor <code-section> | /refactor (no args = fix-ledger mode)
+argument-hint: [file-or-function, or empty for the fix ledger]
+allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *), Bash(git grep *), Bash(git status *), Bash(git rev-parse *), Bash(git switch *)
 ---
 Refactor $ARGUMENTS.
+
+## Ledger mode — `$ARGUMENTS` empty
+Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
+`/branch-review` has accumulated. Everything below (goals, constraints,
+verification, HITL gates) still applies; this section only says what to
+refactor and how to close each item.
+
+1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+   → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
+2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
+3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F
+   "<snippet>" -- <path>`. **No hit → delete the bullet** and list it as
+   "cleaned by other work". Hit → re-read the surrounding code; if the finding
+   no longer holds, delete the bullet with a one-line reason. What survives is
+   the work list.
+4. **Fix the survivors, one bullet per change**, under the constraints below.
+   Delete each bullet as its fix lands. A fix that turns out to need a
+   behaviour change is not a refactor — leave the bullet, note it in the report.
+5. Run the tests as described below. Then report: **fixed / dropped / left**
+   with the reason per left item, and the remaining bullet count.
+6. Say plainly: **commit, then run `/branch-review`** on this branch — ledger
+   mode is a fixer, not a review, and its diff gets the ordinary gate.
 
 ## Goals
 - Reduce complexity

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -75,6 +75,9 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`coverage:` naming any stage `NOT RUN`** → **stop**. A `ready` from a run
+  that skipped the security stage is not the same fact as one that did not,
+  and this line is the only place the difference is visible to you.
 - **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
   Read that line as mechanically as the `sha:` one. A matching SHA proves a
   review ran here; it says nothing about what the review concluded, and

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -80,9 +80,14 @@ that predates this file's introduction has no record, so it does not count.
 
 This phase runs **before** `/release` writes anything, so the docs-and-bump
 commit it makes later cannot invalidate the review it just checked. That
-commit is also where a doc-only ledger item is cheapest to close: correcting
-a stale line during the docs sweep costs nothing, where fixing it on its own
-means a commit, a stale review, and a re-review for one word.
+If Phase 2's docs sweep happens to correct a line that a fix-ledger bullet
+also names, that is ordinary sweep work — the doc changed with the feature,
+so it was already yours to update. **Do not delete the bullet.** `/refactor`
+is the only deleter, and its revalidation will drop that bullet on its next
+run when it finds the finding no longer holds. Deleting it here would make
+`/release` a second writer on state that has exactly one owner, and the whole
+value of the ledger's one-append-one-delete split is that it stays readable
+as a log.
 
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -67,12 +67,11 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically, and only in repos that track the
-  ledger** (it is normally gitignored, in which case it never reaches this
-  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
-  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
-  file is the review's own output, not a change to the code it reviewed. Any
-  other path in that list → stale.
+  **No exceptions — including the fix ledger.** It is normally gitignored, so
+  appending to it moves nothing and this never comes up. A repo that tracks
+  `.claude/` instead will see a ledger commit land after the review and make
+  it stale. That is the rule working, not a case to carve out: re-review, or
+  leave the ledger uncommitted until after the release.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -75,6 +75,12 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
+  Read that line as mechanically as the `sha:` one. A matching SHA proves a
+  review ran here; it says nothing about what the review concluded, and
+  leaving the conclusion to the orchestrator's recollection restores exactly
+  the unverified claim this file replaced. Only `verdict: ready` with a
+  matching SHA is a pass.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -67,6 +67,10 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
+  **One carve-out, checked mechanically:** if `git diff --name-only
+  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
+  nothing else, the review stands — the ledger is the review's own output,
+  committed after it by design. Any other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -160,15 +160,27 @@ orchestrator can run them on the user's named go:
 > Ready when you are:
 > 1. `git push -u origin <branch>`
 > 2. `gh pr create` into `main`
-> 3. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
+> 3. `gh pr checks <pr> --watch` — **merge only on green.** Every gate before
+>    this one ran on the same machine; CI is the only differently-configured
+>    instrument in the chain, and this is the first time it sees the branch.
+>    A test that passes locally because of a path, a fixture, or a tool that
+>    exists only on your box fails here and nowhere earlier. Read the exit
+>    code off the bare command. Red → stop, fix, re-review, and start again.
+> 4. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
 >    owner-authorized admin merge on a solo repo). **Keep `--squash`** — `gh`
 >    requires an explicit merge-method flag (`--squash` / `--merge` /
 >    `--rebase`); drop it and the command will not squash-merge.
-> 4. `git tag vX.Y.Z` on `main` and push the tag
-> 5. Publish **if this project has a publish path** (e.g.
+> 5. `git tag vX.Y.Z` on `main` and push the tag
+> 6. Publish **if this project has a publish path** (e.g.
 >    `gh workflow run publish.yml`) — manual by design
-> 6. Verify it is actually live (`npm view <pkg> version`, and the published
+> 7. Verify it is actually live (`npm view <pkg> version`, and the published
 >    tarball's contents), not the working tree
+
+**Every exit code in this sequence is read off the bare command, including
+the ones you type yourself.** `/ship`'s rule is not just for the worker: a
+pipeline reports its last element's status, so `gh run watch --exit-status |
+tail -2; echo $?` prints `0` for a failed run. That has already turned a red
+CI into a green reading in a real release.
 
 Final line: **Cut ✅ (vX.Y.Z — ready to push)** or **Blocked 🛑** with the
 specific reason.

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -78,6 +78,12 @@ that predates this file's introduction has no record, so it does not count.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 
+This phase runs **before** `/release` writes anything, so the docs-and-bump
+commit it makes later cannot invalidate the review it just checked. That
+commit is also where a doc-only ledger item is cheapest to close: correcting
+a stale line during the docs sweep costs nothing, where fixing it on its own
+means a commit, a stale review, and a re-review for one word.
+
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -67,10 +67,12 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically:** if `git diff --name-only
-  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
-  nothing else, the review stands — the ledger is the review's own output,
-  committed after it by design. Any other path in that list → stale.
+  **One carve-out, checked mechanically, and only in repos that track the
+  ledger** (it is normally gitignored, in which case it never reaches this
+  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
+  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
+  file is the review's own output, not a change to the code it reviewed. Any
+  other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/ampcode/commands/release.md
+++ b/packages/ampcode/commands/release.md
@@ -56,11 +56,14 @@ separate command that must have run first.
 A review must have run on this branch **at the current HEAD SHA**.
 
 **Compare the SHAs yourself; do not settle for an answer.** Run `git rev-parse
-HEAD` and compare it against the SHA the review recorded — `/branch-review`
-ends with `Reviewed at HEAD <sha>`. Asking the orchestrator "did a review run?"
-puts the question to the one party with an incentive to say yes, so its word is
-not evidence: obtain the review's own recorded SHA and match the two strings.
-**No recorded SHA to compare = no review**, never a pass.
+HEAD` and compare it against the `sha:` line in
+`.claude/remember/last-review.md`, which `/branch-review` writes. Asking the
+orchestrator "did a review run?" puts the question to the one party with an
+incentive to say yes, so its word is not evidence — and neither is a SHA
+quoted from a chat message, which is the same claim in another costume and is
+gone after a compaction or a handover. Read the file; match the two strings.
+**No such file, or no `sha:` line in it = no review**, never a pass. A review
+that predates this file's introduction has no record, so it does not count.
 
 - **No review**, or no recorded SHA obtainable → **stop**: "No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."

--- a/packages/ampcode/commands/remember.md
+++ b/packages/ampcode/commands/remember.md
@@ -133,6 +133,14 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      Re-processing a stash whose episode is already filed must not create a near-duplicate
      pair. Every older episode is **folded, then deleted**: its lesson becomes a fact (handed
      to the rewrite above); the narrative is removed. No archive — git has the history.
+     **Specify the operation once.** The keep-10 rule is the rule; the set to remove is
+     *derived* from it, never supplied alongside it as a second list. Given both, an agent
+     applies both and removes their union — observed in the field: a run told to keep 10 and
+     handed a 5-entry delete list removed 7, and the 2 extras were never folded, so one
+     lesson left memory with nothing carrying it. **No episode is removed whose lesson has
+     not been folded into a fact first**, and the two sets must match: state the count
+     before, the count after, and name each episode removed. Removed-but-not-folded is a
+     defect to report, not a tidy-up.
    - **Antigens section**: only update from friction output (step 4)
    - Write merged result to `.amp/remember/MEMORY.md` in the format under step 5.
 
@@ -276,7 +284,11 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
        recurrence; a single occurrence has none to track yet. Friction re-scans every
        session log every run, so a later run matches it back to 2+ sessions and seeds it
        then — this does not change matching against an EXISTING entry, which is recurrence
-       regardless of the matching cluster's own session count.
+       regardless of the matching cluster's own session count. **A match is not an
+       increment.** Whether it counts as a new conversation is decided in 4c by
+       `friction.cjs count`, which is a no-op when that session hash is already stored — so
+       several matches against one entry routinely produce zero increments, and that is
+       correct, not a miscount.
      - For `new:<theme>` groups with no ledger match: distinct conversations = distinct
        cluster indices in the group (within one classify batch, no two cluster indices
        share a session hash). `sessions < 2` → writes nothing. `sessions >= 2` → new entry,
@@ -367,9 +379,17 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      .amp/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
-   - Each marker pair is independent: if AGENT.md already has a given pair, replace the
-     section between them; if not, append it at the end; if no AGENT.md exists, create one
-     containing whichever section(s) apply
+   - Each marker pair is independent: if AGENT.md lacks a given pair, append it at the
+     end; if no AGENT.md exists, create one containing whichever section(s) apply.
+   - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
+     block above is what to write when creating it, not a template to re-impose every run.
+     Users trim this section deliberately (a pointer-only variant is common), and rewriting
+     it silently re-adds text they removed, on every single run, forever. Observed in the
+     field: a run restored the inline rules into a AGENT.md whose owner had cut them, and
+     the edit had to be reverted by hand. This matches how `AGENT_RULES.md` itself is
+     handled — bootstrapped once, never overwritten after.
+   - If an existing pair is present but its **path pointer** is missing or wrong, that is
+     load-bearing: **report it and stop**, do not silently rewrite the section around it.
 
    ```markdown
    # Project Memory

--- a/packages/ampcode/commands/remember.md
+++ b/packages/ampcode/commands/remember.md
@@ -380,7 +380,8 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENT.md lacks a given pair, append it at the
-     end; if no AGENT.md exists, create one containing whichever section(s) apply.
+     end; if a given pair already exists, replace its content in place; if no AGENT.md
+     exists, create one containing whichever section(s) apply.
    - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
      block above is what to write when creating it, not a template to re-impose every run.
      Users trim this section deliberately (a pointer-only variant is common), and rewriting

--- a/packages/ampcode/commands/remember.md
+++ b/packages/ampcode/commands/remember.md
@@ -346,11 +346,23 @@ Reads all raw material (`.amp/stash/*.md` + `.amp/remember/friction/antigen_clus
      inline duplication is needed
    - If `.amp/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
-     — an `@`-reference hot-loads the whole file into every session, and this is a standards
-     guide to consult when designing/building something new, not hot context:
+     markers. Unlike MEMORY.md above, the file itself is **never `@`-referenced** — an
+     `@`-reference hot-loads all ~300 lines into every session, and it is a standards guide
+     to consult when designing/building something new, not hot context. The section carries
+     a path pointer plus exactly two inline rules: the ones that change what you TYPE, which
+     you cannot look up because you do not know you need them. Everything else stays behind
+     the pointer. Write the section verbatim, rules first:
      ```
      <!-- AGENT_RULES:START -->
+     **One writer per piece of state.** One function assigns each field; everything else
+     calls it. Grep who writes it before you write it — and if a write can land from a
+     callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+     **Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you
+     pass: if it's inside or affects the code you're already changing and the fix changes
+     no behavior, fix it and say so — otherwise report it and say what it costs to leave
+     it. A problem you don't fix goes in the report, never in a comment.
+
      Standards guide (read when designing/building something new, not hot context):
      .amp/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->

--- a/packages/ampcode/commands/remember/AGENT_RULES.md
+++ b/packages/ampcode/commands/remember/AGENT_RULES.md
@@ -105,11 +105,14 @@ Before adding any external dependency, all of these must be true:
 
 - **Open-source only.** Always use open-source solutions. No vendor lock-in
 - **Lightweight over complex.** If two solutions solve the same problem, use the one with fewer moving parts, fewer dependencies, and less configuration
-- **Every line must have a purpose.** No speculative code, no "might need this later", no abstractions for one use case
+- **Every line earns its place.** If you can't say what breaks when it's deleted, delete it. No speculative code, no "might need this later", no abstractions for one use case. One function, one concern, one owner — small blocks beat spaghetti
 - **Simple > clever.** Readable code that a junior can follow beats elegant code that requires a PhD to debug
+- **One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it. Ownership says *where*, not *when* — if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh
+- **Split the decision from the machinery.** A branch whose outcome matters, tangled with a framework, IO, or UI object, moves into a pure function; the framework class applies the result. Extract to pin a branch, not to raise coverage — a one-line delegation in its own file buys a test that cannot fail
+- **Claims in comments must be checkable.** "The only place that writes X" is a claim — run the grep first, and expect the next reader to re-run it. A name search proves an edge exists, never that one doesn't
 - **Containerize only when necessary.** Start with a virtualenv or bare metal. Docker adds value for deployment parity and isolation — not for running a script
 - **Responsive web UI is mandatory in dev projects.** Any web UI must be usable on mobile by default — fluid layouts, viewport meta tag, breakpoints for narrow screens, no horizontal scroll. Test in DevTools device emulation before declaring a UI task done. POCs are exempt (validate the idea first), but the moment a POC graduates to a real project this becomes a hard requirement
-- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created — leave pre-existing dead code alone unless asked. Every changed line should trace directly to the request
+- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created. Dead code, nits, bugs you pass on the way: if it's inside or affects the code you're already changing, and the fix changes no behavior, fix it and say so. Otherwise report it — say what it costs to leave it. "It would be nicer" is not a cost. Every changed line traces to the request or to a fix you named
 
 ### Red Flags — Stop and Flag These
 - Over-engineering simple problems
@@ -120,6 +123,8 @@ Before adding any external dependency, all of these must be true:
 - POC-ing only the easy part while hand-waving the risky mechanism, or claiming a cost ("cheap"/"fast"/"constant") you never measured
 - Authoring a fixture/corpus that *guarantees* the result (a test that can't return the negative), or trusting a degenerate-looking number without auditing the harness for confounds — use real uncrafted data; the test must be able to fail
 - Fitting a POC to pass (narrowed input, moved threshold, shrunk scope) instead of reporting the failure; starting module N+1 while module N is unproven
+
+A problem you see and don't fix goes in the report, never in a comment. Comments are where findings go to be forgotten.
 
 ---
 
@@ -291,7 +296,11 @@ Copy this to any project's AGENT.md. These are mandatory rules, not suggestions.
 
 **Lightweight over complex.** Fewer moving parts, fewer deps, less config. Express over NestJS, Flask over Django, unless the project genuinely needs the framework. Simple > clever. Readable > elegant.
 
-**Open-source only.** No vendor lock-in. Every line of code must have a purpose — no speculative code, no premature abstractions.
+**Open-source only.** No vendor lock-in. Every line of code earns its place — if you can't say what breaks when it's deleted, delete it. No speculative code, no premature abstractions.
+
+**One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it — and if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+**Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you pass: if it's inside or affects the code you're already changing and the fix changes no behavior, fix it and say so — otherwise report it and say what it costs to leave it. A problem you don't fix goes in the report, never in a comment.
 
 **Responsive web UI is mandatory.** Any web UI must work on mobile by default — fluid layouts, viewport meta, breakpoints, no horizontal scroll. Verify in DevTools device emulation before claiming a UI task is done. POCs exempt; real projects are not.
 

--- a/packages/ampcode/commands/ship.md
+++ b/packages/ampcode/commands/ship.md
@@ -20,6 +20,22 @@ its exit code**. A check you did not run is a **fail**, never a pass. **N/A
 requires a stated reason** ("no build script in `package.json`") — N/A must
 never stand in for "didn't get to it."
 
+**Capture the exit code of the command itself, never of a pipeline.** Run the
+bare command, then read `$?` on the next line:
+
+```
+node "$f" > /tmp/out 2>&1; e=$?
+```
+
+`$?` after a pipe is the *last element's* status, so the common shape
+`out=$(cmd 2>&1 | tail -1); echo "exit=$?"` reports `tail`'s success — `0` —
+for a suite that exited `2`. Reproduced: a check printing "exit 2:
+prerequisites missing" was recorded as a pass by exactly that loop. Nor does
+`${PIPESTATUS[0]}` rescue it inside a command substitution; it is empty by
+the time you read it. This is the rule the whole gate rests on, and the
+piped form is the natural way to write a multi-suite loop, so it fails
+silently and in the unsafe direction.
+
 ## Checklist
 - [ ] **Tests pass** — run the project's real test command (`npm test`,
       `pytest`, `go test ./...`, `cargo test`, `make test`).

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -200,6 +200,9 @@ missing):
 > Non-blocking review findings. One bullet per item. Delete the bullet when
 > fixed, or when its anchor no longer exists. Written by /branch-review;
 > consumed by /refactor (ledger mode).
+>
+> A bullet's path may be a glob when the same finding exists in every kit —
+> `git grep -F "<snippet>" -- <path>` accepts one.
 
 - `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
   scenario · YYYY-MM-DD @ <short sha>
@@ -208,8 +211,12 @@ missing):
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
-appending, `git grep -F` the snippet in the ledger itself; if it is already
-there, skip it. Do not touch existing bullets.
+appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
+if it is already there, skip it. Do not touch existing bullets. Use plain
+`grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
+and `git grep` searches tracked content only, so it reports "not found" for a
+snippet that is sitting right there — the dedupe would pass every time and
+the same finding would be appended on every run.
 
 Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
 **Failure scenario** (inputs/state → result) · **Why it matters** ·

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -257,7 +257,15 @@ The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
 appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
-if it is already there, skip it. Do not touch existing bullets. Use plain
+if it is already there, skip it. Do not touch existing bullets.
+
+**A bullet you disprove is deleted, not annotated.** If you establish that an
+existing bullet's finding no longer holds — or never did — remove the line and
+say why in your report. The ledger is a work list, not an archive: an
+annotated bullet still reads as work, and a bullet arguing with itself is
+worse than none. Deleting on disproof is the one case where a reviewer may
+remove a line, and it is the same judgement `/refactor` makes at
+revalidation. Use plain
 `grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
 and `git grep` searches tracked content only, so it reports "not found" for a
 snippet that is sitting right there — the dedupe would pass every time and
@@ -325,5 +333,10 @@ End with:
   local artifact; in the usual case it is gitignored, so writing it moves
   nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
+- **A run that produces no record is not a review.** If you die mid-flight —
+  a rate limit, a crash, a cancelled turn — there is no report and no
+  `last-review.md`, and silence must never be read as a pass. `/release`
+  already treats a missing record as no review; state it here too so nobody
+  fills the gap from memory of a run that never finished.
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -46,12 +46,24 @@ at the current HEAD SHA.
   even for a finding you are certain about. Report it. The only files you may
   write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
   delete) and `.claude/remember/last-review.md` (overwrite; the review record
-  described at the end of this file). Re-run `git status --porcelain` before
-  you report: it must be empty or list only those paths — anything else, say
-  what changed. That turns "it never edits" from a claim into a checked
-  fact.
+  described at the end of this file).
+- **Prove it with two checks, because neither sees what the other does.**
+  `git status --porcelain`, at start and again before you report, proves no
+  **tracked** file changed — that is the "never edits code" guarantee, and it
+  is the one that matters. It cannot police your own two writes: `.claude/`
+  is normally gitignored, so porcelain stays empty whether you wrote the
+  allowed files, wrote nothing, or overwrote `MEMORY.md`. `git status
+  --ignored` does not close it either — it collapses to `!! .claude/`, the
+  directory, not the files. So also take `md5sum .claude/remember/*` before
+  you start and again before you report, and show the comparison: only
+  `fix-ledger.md` and `last-review.md` may differ.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
+
+**The orchestrator runs this check before spawning anyone**, so a dirty tree
+costs no worker; the worker then re-runs it as its own first act, because a
+review that takes the tree's state on trust is the thing this command exists
+not to do. Both, not either.
 
 **Before resolving anything, run `git status --porcelain`.** If it prints any
 line — modified, staged, or untracked — **stop and report it**. Say all three
@@ -201,7 +213,8 @@ including in a doc or spec. But prose is not automatically harmless: in a repo
 whose deliverable *is* a specification, a **normative requirement stated two
 incompatible ways** is a reproduced defect, because two conforming
 implementations built from it diverge. Judge by whether a behaviour changes,
-not by whether the file holds code. A finding already dismissed with evidence in this project's stash
+not by whether the file holds code — and judge it **per finding, not per
+repo**, since a diff mixing code and specification is the normal case. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -11,9 +11,11 @@ reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
 Only **Critical** and **High** findings block the merge. Everything else is
-appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
-committed, cumulative list that `/refactor` (no arguments) works through
-between features. The report is blockers plus the ledger count, so a review
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a local,
+cumulative list, living beside `MEMORY.md`, that `/refactor` (no arguments)
+works through between features. Like its neighbours it is a private working
+artifact, usually gitignored; it persists across reviews, it is not a
+deliverable. The report is blockers plus the ledger count, so a review
 converges instead of surfacing fresh nits every run. This command never runs
 `/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
 
@@ -222,8 +224,9 @@ End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
   tree clean at start; at exit clean or `fix-ledger.md` only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
-  add: "N fixes waiting — run `/refactor` between features." The orchestrator
-  commits the ledger; `/release` accepts a ledger-only commit after the review.
+  add: "N fixes waiting — run `/refactor` between features." The ledger is a
+  local artifact; in the usual case it is gitignored, so writing it moves
+  nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -104,6 +104,14 @@ its exit code.
   "temporary" names, abandoned feature flags.
 - **Correctness.** Edge cases, error handling, type / contract violations,
   broken invariants.
+- **State ownership.** Two or more functions assigning the same field, flag, or
+  view property. A finding on its own — no failing case required. `git grep`
+  every assignment to that name repo-wide, not just in the diff; the second
+  writer is usually in a file the diff never touched. Name both writers with
+  `file:line` — an unnamed second writer is a hunch, not a finding. Count
+  ordering, not just writers: a write arriving from a callback, thread, or
+  lifecycle event is the dangerous one, and one app writer racing a framework
+  one still counts as two.
 - **Performance.** N+1, blocking calls in hot paths, unbounded loops, indexes
   the diff actually touches.
 - **Test quality, not just test presence.** For every test the diff adds or

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -95,12 +95,23 @@ Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
 
-**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
-Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
-blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
-**not** re-judged. A full re-read of an already-reviewed branch produces fresh
-findings every time and never converges. The range form still ends at HEAD,
-so `/release`'s precondition is satisfied.
+**Re-review after fixes: read `.claude/remember/last-review.md` first.** Its
+`sha:` line is the previously-reviewed commit and its `blockers:` list is what
+you owe an answer on — take both from the file, never from the orchestrator's
+recollection, for the same reason `/release` does. Then:
+
+- **`sha:` ≠ HEAD** → this is a re-review. Target the range
+  `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
+  re-verifies each recorded blocker as fixed, unfixed, or dismissed with a
+  reason. The rest of the branch is **not** re-judged: a full re-read of an
+  already-reviewed branch produces fresh findings every run and never
+  converges. The range still ends at HEAD, so `/release`'s precondition is
+  satisfied and the new record replaces the old one.
+- **`sha:` = HEAD** → nothing has changed since the last review. Say so and
+  stop; re-running against an identical tree can only produce noise. If the
+  recorded verdict was `blocked`, its blockers are still unfixed by
+  definition — repeat them rather than re-deriving them.
+- **No file** → no prior review to build on. Review the whole branch.
 
 **On a re-review, sweep the open ledger bullets for liveness first.** Their
 anchors may sit in the part of the branch you are no longer reading, and the

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -42,12 +42,14 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits — one exception.** You have no authorization to change code,
-  even for a finding you are certain about. Report it. The **only** file you
-  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
-  or delete). Re-run `git status --porcelain` before you report: it must be
-  empty or list exactly that one path — anything else, say what changed. That
-  turns "it never edits" from a claim into a checked fact.
+- **No edits — two exceptions.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The only files you may
+  write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
+  delete) and `.claude/remember/last-review.md` (overwrite; the review record
+  described at the end of this file). Re-run `git status --porcelain` before
+  you report: it must be empty or list only those paths — anything else, say
+  what changed. That turns "it never edits" from a claim into a checked
+  fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
 
@@ -87,6 +89,12 @@ blockers (fixed / unfixed / dismissed — with reason); the rest of the branch i
 **not** re-judged. A full re-read of an already-reviewed branch produces fresh
 findings every time and never converges. The range form still ends at HEAD,
 so `/release`'s precondition is satisfied.
+
+**On a re-review, sweep the open ledger bullets for liveness first.** Their
+anchors may sit in the part of the branch you are no longer reading, and the
+fix commits you *are* reading can invalidate them. `grep -F` each open
+snippet against its path; report any whose anchor is gone so `/refactor` can
+drop them. Cheap, and it stops dead bullets accumulating unseen.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -185,8 +193,12 @@ Then the findings, ordered most severe first.
 ### 🚨 Critical / High (blocks merge)
 A **reproduced** failure only: a failing test, a broken build, a security
 exposure, or a bug with a written failure scenario you confirmed in stage 3.
-A finding about a spec's or doc's own prose, structure, or style is **never**
-a blocker. A finding already dismissed with evidence in this project's stash
+A finding about **style, wording or structure** is **never** a blocker —
+including in a doc or spec. But prose is not automatically harmless: in a repo
+whose deliverable *is* a specification, a **normative requirement stated two
+incompatible ways** is a reproduced defect, because two conforming
+implementations built from it diverge. Judge by whether a behaviour changes,
+not by whether the file holds code. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 
@@ -208,6 +220,12 @@ missing):
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
+**A ledger bullet's failure scenario is subject to stage 3 like any other.**
+Ledger items skip the report, so they are easy to skip verifying too, and an
+unverified consequence written in the bullet's voice reads as established
+fact to whoever fixes it later. Either confirm it, or prefix the scenario
+with `UNVERIFIED:` so `/refactor` retests before acting.
+
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
@@ -227,9 +245,24 @@ Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
 each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
+**Write the review record** to `.claude/remember/last-review.md`, overwriting
+it. `/release` reads this file; a SHA that lives only in a chat message is
+gone after a compaction or a handover, and the only remaining source is the
+orchestrator — the one party this command already refuses to take a review's
+word from. Exactly these five lines:
+
+```
+sha: <full HEAD sha>
+branch: <branch>
+target: <resolved range or path>
+verdict: <ready | blocked>
+date: <YYYY-MM-DD>
+```
+
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start; at exit clean or `fix-ledger.md` only.**
+  tree clean at start; at exit clean or the two `.claude/remember/` paths
+  only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
   add: "N fixes waiting — run `/refactor` between features." The ledger is a
   local artifact; in the usual case it is gitignored, so writing it moves

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -265,15 +265,45 @@ assumed pass.
 it. `/release` reads this file; a SHA that lives only in a chat message is
 gone after a compaction or a handover, and the only remaining source is the
 orchestrator — the one party this command already refuses to take a review's
-word from. Exactly these five lines:
+word from. **Write it at the end of every run, unconditionally** — not after
+someone decides what to do about it. The information exists now, and the file
+earns its keep only by surviving a compaction, an abandoned session, or a
+handover to someone who never saw the report.
 
 ```
 sha: <full HEAD sha>
 branch: <branch>
 target: <resolved range or path>
+level: <low | medium | high | max>
 verdict: <ready | blocked>
 date: <YYYY-MM-DD>
+coverage: stage1 <ran|NOT RUN>, stage2 <ran|NOT RUN>, stage3 <ran|NOT RUN>
+blockers:
+- <file:line> · <one-sentence claim, no scenario, no suggested fix>
 ```
+
+`blockers: none` when the verdict is ready. One line per blocker and nothing
+more: the reasoning belongs in the report, and the non-blocking findings
+belong in the ledger. This exists so a session that never saw the report can
+learn *what* is blocked, not just *that* something is — otherwise the next
+run rediscovers it by re-reviewing the branch, which is the
+non-convergence this command exists to stop.
+
+`coverage` is recorded because a `ready` from a run whose security stage did
+not execute is not the same fact as one where it did, and the reader of this
+file cannot tell them apart otherwise.
+
+**There is no override field, and no `verdict: overridden`.** A SHA is
+checkable by anyone; consent is not, so a consent line in a file is forgeable
+by whatever writes the file — and a persisted override is reusable, silently
+covering the next release as well as this one. Releasing over a blocked
+review is a live decision made at `/release`'s hand-back, in conversation.
+
+**Nothing clears this file.** It is overwritten whole on the next run, and the
+`sha:` line is what expires it: fix something, commit, and the recorded hash
+no longer matches HEAD, so the gate reports *stale* and asks for a
+re-review rather than *blocked*. A blocked verdict can only persist while HEAD
+does not move — which means nothing was fixed, which is the correct outcome.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -118,7 +118,10 @@ judging.
 not a fact to accept. Branches are commonly AI-authored now — including the
 fixes to the fixes — so a review that trusts the message is reviewing prose.
 Run the test suite and the typecheck/build yourself and cite the command and
-its exit code.
+its exit code. Read that code off the bare command (`cmd > /tmp/out 2>&1;
+e=$?`), never off a pipeline — `$?` after a pipe is the last element's
+status, so piping into `tail` reports `0` for a suite that failed. `/ship`
+carries the reproduction.
 
 - **Bugs needing a fix.** Logic errors, off-by-one, null/undefined paths,
   races, wrong defaults, broken edge cases.

--- a/packages/claude/commands/branch-review.md
+++ b/packages/claude/commands/branch-review.md
@@ -10,6 +10,13 @@ audit** — followed by an adversarial verify pass. It **never edits code**: it
 reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
+Only **Critical** and **High** findings block the merge. Everything else is
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
+committed, cumulative list that `/refactor` (no arguments) works through
+between features. The report is blockers plus the ledger count, so a review
+converges instead of surfacing fresh nits every run. This command never runs
+`/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
+
 Run this **before** `/release`. `/release` will refuse to run without a review
 at the current HEAD SHA.
 
@@ -33,9 +40,11 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits.** You have no authorization to change code, even for a finding
-  you are certain about. Report it. Re-run `git status --porcelain` before you
-  report and confirm it is still empty — if it is not, say what changed. That
+- **No edits — one exception.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The **only** file you
+  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
+  or delete). Re-run `git status --porcelain` before you report: it must be
+  empty or list exactly that one path — anything else, say what changed. That
   turns "it never edits" from a claim into a checked fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
@@ -69,6 +78,13 @@ With a clean tree, interpret `$ARGUMENTS` in this order:
 Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
+
+**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
+Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
+blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
+**not** re-judged. A full re-read of an already-reviewed branch produces fresh
+findings every time and never converges. The range form still ends at HEAD,
+so `/release`'s precondition is satisfied.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -164,21 +180,50 @@ verdict first, then repeat it at the end.
 
 Then the findings, ordered most severe first.
 
-### 🚨 Critical (blocks merge)
-### ⚠️ Warnings (should fix)
-### 💡 Suggestions (nice to have)
+### 🚨 Critical / High (blocks merge)
+A **reproduced** failure only: a failing test, a broken build, a security
+exposure, or a bug with a written failure scenario you confirmed in stage 3.
+A finding about a spec's or doc's own prose, structure, or style is **never**
+a blocker. A finding already dismissed with evidence in this project's stash
+or memory cannot come back at a higher severity without **new** evidence —
+check before escalating.
 
-Each finding: **Location** (`file:line`) · **What's wrong** · **Failure
-scenario** (inputs/state → result) · **Why it matters** · **Suggested fix**
-(described, not applied) · **Verdict** (confirmed / uncertain).
+### Ledger (non-blocking — medium / low)
+Not in the report. **Append** each one as a single bullet to
+`.claude/remember/fix-ledger.md` (create the file with the header below if
+missing):
 
-Then a coverage line: stage 1 at level `<level>`, stage 2 full — each `ran ✓/✗`
-with its evidence. A stage you did not actually run is a **✗**, never an
+```
+# Fix ledger
+> Non-blocking review findings. One bullet per item. Delete the bullet when
+> fixed, or when its anchor no longer exists. Written by /branch-review;
+> consumed by /refactor (ledger mode).
+
+- `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
+  scenario · YYYY-MM-DD @ <short sha>
+```
+
+The **snippet is the anchor**: 20–60 verbatim characters from the line,
+unique enough for `git grep -F` to find it after lines shift. No line
+numbers, no TODO comments in code — the ledger is the single writer. Before
+appending, `git grep -F` the snippet in the ledger itself; if it is already
+there, skip it. Do not touch existing bullets.
+
+Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
+**Failure scenario** (inputs/state → result) · **Why it matters** ·
+**Suggested fix** (described, not applied) · **Verdict** (confirmed /
+uncertain).
+
+Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
+each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start and at exit.**
+  tree clean at start; at exit clean or `fix-ledger.md` only.**
+- **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
+  add: "N fixes waiting — run `/refactor` between features." The orchestrator
+  commits the ledger; `/release` accepts a ledger-only commit after the review.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/claude/commands/refactor.md
+++ b/packages/claude/commands/refactor.md
@@ -1,11 +1,33 @@
 ---
 name: refactor
 description: Refactor [code]
-usage: /refactor <code-section>
-argument-hint: [file-or-function]
-allowed-tools: Read, Edit, Grep, Glob, Bash(npm test:*), Bash(npx jest:*), Bash(npx vitest:*), Bash(pnpm test:*), Bash(yarn test:*), Bash(pytest:*), Bash(python:*), Bash(go test:*), Bash(cargo test:*), Bash(make test:*), Bash(git diff:*)
+usage: /refactor <code-section> | /refactor (no args = fix-ledger mode)
+argument-hint: [file-or-function, or empty for the fix ledger]
+allowed-tools: Read, Edit, Grep, Glob, Bash(npm test:*), Bash(npx jest:*), Bash(npx vitest:*), Bash(pnpm test:*), Bash(yarn test:*), Bash(pytest:*), Bash(python:*), Bash(go test:*), Bash(cargo test:*), Bash(make test:*), Bash(git diff:*), Bash(git grep:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git switch:*)
 ---
 Refactor $ARGUMENTS.
+
+## Ledger mode — `$ARGUMENTS` empty
+Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
+`/branch-review` has accumulated. Everything below (goals, constraints,
+verification, HITL gates) still applies; this section only says what to
+refactor and how to close each item.
+
+1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+   → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
+2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
+3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F
+   "<snippet>" -- <path>`. **No hit → delete the bullet** and list it as
+   "cleaned by other work". Hit → re-read the surrounding code; if the finding
+   no longer holds, delete the bullet with a one-line reason. What survives is
+   the work list.
+4. **Fix the survivors, one bullet per change**, under the constraints below.
+   Delete each bullet as its fix lands. A fix that turns out to need a
+   behaviour change is not a refactor — leave the bullet, note it in the report.
+5. Run the tests as described below. Then report: **fixed / dropped / left**
+   with the reason per left item, and the remaining bullet count.
+6. Say plainly: **commit, then run `/branch-review`** on this branch — ledger
+   mode is a fixer, not a review, and its diff gets the ordinary gate.
 
 ## Goals
 - Reduce complexity

--- a/packages/claude/commands/refactor.md
+++ b/packages/claude/commands/refactor.md
@@ -57,7 +57,9 @@ Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 verification, HITL gates) still applies; this section only says what to
 refactor and how to close each item.
 
-1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+1. **Tree must be clean and not on `main`.** The orchestrator runs this check
+   before spawning the worker, so a dirty tree costs no worker; the worker
+   then re-runs it as its own first act. `git status --porcelain` non-empty
    → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
 2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
 3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F

--- a/packages/claude/commands/refactor.md
+++ b/packages/claude/commands/refactor.md
@@ -7,6 +7,50 @@ allowed-tools: Read, Edit, Grep, Glob, Bash(npm test:*), Bash(npx jest:*), Bash(
 ---
 Refactor $ARGUMENTS.
 
+## Guardrails
+- **Spawn a worker and explicitly select your tool's mid tier.** State the
+  tier on the spawn — do not omit it and rely on a default. An omitted tier
+  inherits the *parent's* tier, which is not the same thing as the balanced
+  one. Pick the judgment-capable tier that is cheaper and faster than your top
+  reasoning tier. **Not the cheapest/fastest tier**: on judgment work it
+  measurably degrades (misclassification rates several times higher). Choose by
+  tier, not by a vendor model name copied from this file — names drift, and
+  this command ships to several tools. Fall back to running inline if your tool
+  has no subagent mechanism.
+- **Escalate, never assume.** Anything you cannot decide, cannot verify, or
+  that this spec does not cover → **stop and report it to the orchestrator**
+  (the main session). Never improvise, never widen scope, never fix a side
+  issue you noticed along the way.
+- **The worker does the work itself — no delegation.** The fixer must **not**
+  spawn subagents of its own. Every edit it reports, and every test run it
+  cites, has to be one it made or ran with its own tool calls: a relayed "I
+  fixed it and the suite is green" from a sub-worker is hearsay, and this
+  command's whole output is the claim that a change landed and the tests still
+  pass. A fix that delegates its work is a report about a report.
+- **The HITL gates below belong to the orchestrator, not the worker.** A
+  subagent cannot hold a conversation with the user, so it cannot run a gate
+  that ends in *stop and ask*. When one trips — a failing test, a crossed
+  public API boundary, a change bigger than the bullet asked for — the worker
+  **stops there and hands the situation back**, with the options and its
+  reasoning but no choice made. The orchestrator asks. A worker that picks
+  revert / patch / update-test on the user's behalf has answered a question it
+  was never allowed to ask.
+- **Edit only what a surviving bullet names.** Ledger mode's scope is the
+  bullets that survive revalidation, one change per bullet — not the
+  neighbouring code, not the formatting, not a second finding noticed on the
+  way past. Anything else goes back to the orchestrator to become a new
+  bullet.
+- **Prove the blast radius with two checks, because neither sees what the
+  other does.** `git status --porcelain` at exit must list only files a
+  surviving bullet named — that is this command's scope guarantee, and unlike
+  `/branch-review` it is not expected to be empty. It cannot police the
+  memory directory: `.claude/` is normally gitignored, so porcelain stays
+  empty whether you deleted a fixed bullet, wrote nothing, or overwrote
+  `MEMORY.md`. So also take `md5sum .claude/remember/*` before you start and
+  again before you report, and show the comparison: only `fix-ledger.md` may
+  differ. `last-review.md` in particular is `/branch-review`'s to write —
+  a fixer that touches it forges the gate that judges its own work.
+
 ## Ledger mode — `$ARGUMENTS` empty
 Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 `/branch-review` has accumulated. Everything below (goals, constraints,

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -75,6 +75,9 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`coverage:` naming any stage `NOT RUN`** → **stop**. A `ready` from a run
+  that skipped the security stage is not the same fact as one that did not,
+  and this line is the only place the difference is visible to you.
 - **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
   Read that line as mechanically as the `sha:` one. A matching SHA proves a
   review ran here; it says nothing about what the review concluded, and

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -80,9 +80,14 @@ that predates this file's introduction has no record, so it does not count.
 
 This phase runs **before** `/release` writes anything, so the docs-and-bump
 commit it makes later cannot invalidate the review it just checked. That
-commit is also where a doc-only ledger item is cheapest to close: correcting
-a stale line during the docs sweep costs nothing, where fixing it on its own
-means a commit, a stale review, and a re-review for one word.
+If Phase 2's docs sweep happens to correct a line that a fix-ledger bullet
+also names, that is ordinary sweep work — the doc changed with the feature,
+so it was already yours to update. **Do not delete the bullet.** `/refactor`
+is the only deleter, and its revalidation will drop that bullet on its next
+run when it finds the finding no longer holds. Deleting it here would make
+`/release` a second writer on state that has exactly one owner, and the whole
+value of the ledger's one-append-one-delete split is that it stays readable
+as a log.
 
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -67,12 +67,11 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically, and only in repos that track the
-  ledger** (it is normally gitignored, in which case it never reaches this
-  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
-  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
-  file is the review's own output, not a change to the code it reviewed. Any
-  other path in that list → stale.
+  **No exceptions — including the fix ledger.** It is normally gitignored, so
+  appending to it moves nothing and this never comes up. A repo that tracks
+  `.claude/` instead will see a ledger commit land after the review and make
+  it stale. That is the rule working, not a case to carve out: re-review, or
+  leave the ledger uncommitted until after the release.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -75,6 +75,12 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
+  Read that line as mechanically as the `sha:` one. A matching SHA proves a
+  review ran here; it says nothing about what the review concluded, and
+  leaving the conclusion to the orchestrator's recollection restores exactly
+  the unverified claim this file replaced. Only `verdict: ready` with a
+  matching SHA is a pass.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -67,6 +67,10 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
+  **One carve-out, checked mechanically:** if `git diff --name-only
+  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
+  nothing else, the review stands — the ledger is the review's own output,
+  committed after it by design. Any other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -160,15 +160,27 @@ orchestrator can run them on the user's named go:
 > Ready when you are:
 > 1. `git push -u origin <branch>`
 > 2. `gh pr create` into `main`
-> 3. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
+> 3. `gh pr checks <pr> --watch` — **merge only on green.** Every gate before
+>    this one ran on the same machine; CI is the only differently-configured
+>    instrument in the chain, and this is the first time it sees the branch.
+>    A test that passes locally because of a path, a fixture, or a tool that
+>    exists only on your box fails here and nowhere earlier. Read the exit
+>    code off the bare command. Red → stop, fix, re-review, and start again.
+> 4. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
 >    owner-authorized admin merge on a solo repo). **Keep `--squash`** — `gh`
 >    requires an explicit merge-method flag (`--squash` / `--merge` /
 >    `--rebase`); drop it and the command will not squash-merge.
-> 4. `git tag vX.Y.Z` on `main` and push the tag
-> 5. Publish **if this project has a publish path** (e.g.
+> 5. `git tag vX.Y.Z` on `main` and push the tag
+> 6. Publish **if this project has a publish path** (e.g.
 >    `gh workflow run publish.yml`) — manual by design
-> 6. Verify it is actually live (`npm view <pkg> version`, and the published
+> 7. Verify it is actually live (`npm view <pkg> version`, and the published
 >    tarball's contents), not the working tree
+
+**Every exit code in this sequence is read off the bare command, including
+the ones you type yourself.** `/ship`'s rule is not just for the worker: a
+pipeline reports its last element's status, so `gh run watch --exit-status |
+tail -2; echo $?` prints `0` for a failed run. That has already turned a red
+CI into a green reading in a real release.
 
 Final line: **Cut ✅ (vX.Y.Z — ready to push)** or **Blocked 🛑** with the
 specific reason.

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -78,6 +78,12 @@ that predates this file's introduction has no record, so it does not count.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 
+This phase runs **before** `/release` writes anything, so the docs-and-bump
+commit it makes later cannot invalidate the review it just checked. That
+commit is also where a doc-only ledger item is cheapest to close: correcting
+a stale line during the docs sweep costs nothing, where fixing it on its own
+means a commit, a stale review, and a re-review for one word.
+
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -67,10 +67,12 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically:** if `git diff --name-only
-  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
-  nothing else, the review stands — the ledger is the review's own output,
-  committed after it by design. Any other path in that list → stale.
+  **One carve-out, checked mechanically, and only in repos that track the
+  ledger** (it is normally gitignored, in which case it never reaches this
+  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
+  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
+  file is the review's own output, not a change to the code it reviewed. Any
+  other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/claude/commands/release.md
+++ b/packages/claude/commands/release.md
@@ -56,11 +56,14 @@ separate command that must have run first.
 A review must have run on this branch **at the current HEAD SHA**.
 
 **Compare the SHAs yourself; do not settle for an answer.** Run `git rev-parse
-HEAD` and compare it against the SHA the review recorded — `/branch-review`
-ends with `Reviewed at HEAD <sha>`. Asking the orchestrator "did a review run?"
-puts the question to the one party with an incentive to say yes, so its word is
-not evidence: obtain the review's own recorded SHA and match the two strings.
-**No recorded SHA to compare = no review**, never a pass.
+HEAD` and compare it against the `sha:` line in
+`.claude/remember/last-review.md`, which `/branch-review` writes. Asking the
+orchestrator "did a review run?" puts the question to the one party with an
+incentive to say yes, so its word is not evidence — and neither is a SHA
+quoted from a chat message, which is the same claim in another costume and is
+gone after a compaction or a handover. Read the file; match the two strings.
+**No such file, or no `sha:` line in it = no review**, never a pass. A review
+that predates this file's introduction has no record, so it does not count.
 
 - **No review**, or no recorded SHA obtainable → **stop**: "No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."

--- a/packages/claude/commands/remember.md
+++ b/packages/claude/commands/remember.md
@@ -380,7 +380,8 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if CLAUDE.md lacks a given pair, append it at the
-     end; if no CLAUDE.md exists, create one containing whichever section(s) apply.
+     end; if a given pair already exists, replace its content in place; if no CLAUDE.md
+     exists, create one containing whichever section(s) apply.
    - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
      block above is what to write when creating it, not a template to re-impose every run.
      Users trim this section deliberately (a pointer-only variant is common), and rewriting

--- a/packages/claude/commands/remember.md
+++ b/packages/claude/commands/remember.md
@@ -133,6 +133,14 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      Re-processing a stash whose episode is already filed must not create a near-duplicate
      pair. Every older episode is **folded, then deleted**: its lesson becomes a fact (handed
      to the rewrite above); the narrative is removed. No archive — git has the history.
+     **Specify the operation once.** The keep-10 rule is the rule; the set to remove is
+     *derived* from it, never supplied alongside it as a second list. Given both, an agent
+     applies both and removes their union — observed in the field: a run told to keep 10 and
+     handed a 5-entry delete list removed 7, and the 2 extras were never folded, so one
+     lesson left memory with nothing carrying it. **No episode is removed whose lesson has
+     not been folded into a fact first**, and the two sets must match: state the count
+     before, the count after, and name each episode removed. Removed-but-not-folded is a
+     defect to report, not a tidy-up.
    - **Antigens section**: only update from friction output (step 4)
    - Write merged result to `.claude/remember/MEMORY.md` in the format under step 5.
 
@@ -276,7 +284,11 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
        recurrence; a single occurrence has none to track yet. Friction re-scans every
        session log every run, so a later run matches it back to 2+ sessions and seeds it
        then — this does not change matching against an EXISTING entry, which is recurrence
-       regardless of the matching cluster's own session count.
+       regardless of the matching cluster's own session count. **A match is not an
+       increment.** Whether it counts as a new conversation is decided in 4c by
+       `friction.cjs count`, which is a no-op when that session hash is already stored — so
+       several matches against one entry routinely produce zero increments, and that is
+       correct, not a miscount.
      - For `new:<theme>` groups with no ledger match: distinct conversations = distinct
        cluster indices in the group (within one classify batch, no two cluster indices
        share a session hash). `sessions < 2` → writes nothing. `sessions >= 2` → new entry,
@@ -367,9 +379,17 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      .claude/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
-   - Each marker pair is independent: if CLAUDE.md already has a given pair, replace the
-     section between them; if not, append it at the end; if no CLAUDE.md exists, create one
-     containing whichever section(s) apply
+   - Each marker pair is independent: if CLAUDE.md lacks a given pair, append it at the
+     end; if no CLAUDE.md exists, create one containing whichever section(s) apply.
+   - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
+     block above is what to write when creating it, not a template to re-impose every run.
+     Users trim this section deliberately (a pointer-only variant is common), and rewriting
+     it silently re-adds text they removed, on every single run, forever. Observed in the
+     field: a run restored the inline rules into a CLAUDE.md whose owner had cut them, and
+     the edit had to be reverted by hand. This matches how `AGENT_RULES.md` itself is
+     handled — bootstrapped once, never overwritten after.
+   - If an existing pair is present but its **path pointer** is missing or wrong, that is
+     load-bearing: **report it and stop**, do not silently rewrite the section around it.
 
    ```markdown
    # Project Memory

--- a/packages/claude/commands/remember.md
+++ b/packages/claude/commands/remember.md
@@ -346,11 +346,23 @@ Reads all raw material (`.claude/stash/*.md` + `.claude/remember/friction/antige
      inline duplication is needed
    - If `.claude/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
-     — an `@`-reference hot-loads the whole file into every session, and this is a standards
-     guide to consult when designing/building something new, not hot context:
+     markers. Unlike MEMORY.md above, the file itself is **never `@`-referenced** — an
+     `@`-reference hot-loads all ~300 lines into every session, and it is a standards guide
+     to consult when designing/building something new, not hot context. The section carries
+     a path pointer plus exactly two inline rules: the ones that change what you TYPE, which
+     you cannot look up because you do not know you need them. Everything else stays behind
+     the pointer. Write the section verbatim, rules first:
      ```
      <!-- AGENT_RULES:START -->
+     **One writer per piece of state.** One function assigns each field; everything else
+     calls it. Grep who writes it before you write it — and if a write can land from a
+     callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+     **Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you
+     pass: if it's inside or affects the code you're already changing and the fix changes
+     no behavior, fix it and say so — otherwise report it and say what it costs to leave
+     it. A problem you don't fix goes in the report, never in a comment.
+
      Standards guide (read when designing/building something new, not hot context):
      .claude/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->

--- a/packages/claude/commands/remember/AGENT_RULES.md
+++ b/packages/claude/commands/remember/AGENT_RULES.md
@@ -105,11 +105,14 @@ Before adding any external dependency, all of these must be true:
 
 - **Open-source only.** Always use open-source solutions. No vendor lock-in
 - **Lightweight over complex.** If two solutions solve the same problem, use the one with fewer moving parts, fewer dependencies, and less configuration
-- **Every line must have a purpose.** No speculative code, no "might need this later", no abstractions for one use case
+- **Every line earns its place.** If you can't say what breaks when it's deleted, delete it. No speculative code, no "might need this later", no abstractions for one use case. One function, one concern, one owner — small blocks beat spaghetti
 - **Simple > clever.** Readable code that a junior can follow beats elegant code that requires a PhD to debug
+- **One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it. Ownership says *where*, not *when* — if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh
+- **Split the decision from the machinery.** A branch whose outcome matters, tangled with a framework, IO, or UI object, moves into a pure function; the framework class applies the result. Extract to pin a branch, not to raise coverage — a one-line delegation in its own file buys a test that cannot fail
+- **Claims in comments must be checkable.** "The only place that writes X" is a claim — run the grep first, and expect the next reader to re-run it. A name search proves an edge exists, never that one doesn't
 - **Containerize only when necessary.** Start with a virtualenv or bare metal. Docker adds value for deployment parity and isolation — not for running a script
 - **Responsive web UI is mandatory in dev projects.** Any web UI must be usable on mobile by default — fluid layouts, viewport meta tag, breakpoints for narrow screens, no horizontal scroll. Test in DevTools device emulation before declaring a UI task done. POCs are exempt (validate the idea first), but the moment a POC graduates to a real project this becomes a hard requirement
-- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created — leave pre-existing dead code alone unless asked. Every changed line should trace directly to the request
+- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created. Dead code, nits, bugs you pass on the way: if it's inside or affects the code you're already changing, and the fix changes no behavior, fix it and say so. Otherwise report it — say what it costs to leave it. "It would be nicer" is not a cost. Every changed line traces to the request or to a fix you named
 
 ### Red Flags — Stop and Flag These
 - Over-engineering simple problems
@@ -120,6 +123,8 @@ Before adding any external dependency, all of these must be true:
 - POC-ing only the easy part while hand-waving the risky mechanism, or claiming a cost ("cheap"/"fast"/"constant") you never measured
 - Authoring a fixture/corpus that *guarantees* the result (a test that can't return the negative), or trusting a degenerate-looking number without auditing the harness for confounds — use real uncrafted data; the test must be able to fail
 - Fitting a POC to pass (narrowed input, moved threshold, shrunk scope) instead of reporting the failure; starting module N+1 while module N is unproven
+
+A problem you see and don't fix goes in the report, never in a comment. Comments are where findings go to be forgotten.
 
 ---
 
@@ -291,7 +296,11 @@ Copy this to any project's CLAUDE.md. These are mandatory rules, not suggestions
 
 **Lightweight over complex.** Fewer moving parts, fewer deps, less config. Express over NestJS, Flask over Django, unless the project genuinely needs the framework. Simple > clever. Readable > elegant.
 
-**Open-source only.** No vendor lock-in. Every line of code must have a purpose — no speculative code, no premature abstractions.
+**Open-source only.** No vendor lock-in. Every line of code earns its place — if you can't say what breaks when it's deleted, delete it. No speculative code, no premature abstractions.
+
+**One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it — and if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+**Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you pass: if it's inside or affects the code you're already changing and the fix changes no behavior, fix it and say so — otherwise report it and say what it costs to leave it. A problem you don't fix goes in the report, never in a comment.
 
 **Responsive web UI is mandatory.** Any web UI must work on mobile by default — fluid layouts, viewport meta, breakpoints, no horizontal scroll. Verify in DevTools device emulation before claiming a UI task is done. POCs exempt; real projects are not.
 

--- a/packages/claude/commands/ship.md
+++ b/packages/claude/commands/ship.md
@@ -20,6 +20,22 @@ its exit code**. A check you did not run is a **fail**, never a pass. **N/A
 requires a stated reason** ("no build script in `package.json`") — N/A must
 never stand in for "didn't get to it."
 
+**Capture the exit code of the command itself, never of a pipeline.** Run the
+bare command, then read `$?` on the next line:
+
+```
+node "$f" > /tmp/out 2>&1; e=$?
+```
+
+`$?` after a pipe is the *last element's* status, so the common shape
+`out=$(cmd 2>&1 | tail -1); echo "exit=$?"` reports `tail`'s success — `0` —
+for a suite that exited `2`. Reproduced: a check printing "exit 2:
+prerequisites missing" was recorded as a pass by exactly that loop. Nor does
+`${PIPESTATUS[0]}` rescue it inside a command substitution; it is empty by
+the time you read it. This is the rule the whole gate rests on, and the
+piped form is the natural way to write a multi-suite loop, so it fails
+silently and in the unsafe direction.
+
 ## Checklist
 - [ ] **Tests pass** — run the project's real test command (`npm test`,
       `pytest`, `go test ./...`, `cargo test`, `make test`).

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -200,6 +200,9 @@ missing):
 > Non-blocking review findings. One bullet per item. Delete the bullet when
 > fixed, or when its anchor no longer exists. Written by /branch-review;
 > consumed by /refactor (ledger mode).
+>
+> A bullet's path may be a glob when the same finding exists in every kit —
+> `git grep -F "<snippet>" -- <path>` accepts one.
 
 - `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
   scenario · YYYY-MM-DD @ <short sha>
@@ -208,8 +211,12 @@ missing):
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
-appending, `git grep -F` the snippet in the ledger itself; if it is already
-there, skip it. Do not touch existing bullets.
+appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
+if it is already there, skip it. Do not touch existing bullets. Use plain
+`grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
+and `git grep` searches tracked content only, so it reports "not found" for a
+snippet that is sitting right there — the dedupe would pass every time and
+the same finding would be appended on every run.
 
 Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
 **Failure scenario** (inputs/state → result) · **Why it matters** ·

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -257,7 +257,15 @@ The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
 appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
-if it is already there, skip it. Do not touch existing bullets. Use plain
+if it is already there, skip it. Do not touch existing bullets.
+
+**A bullet you disprove is deleted, not annotated.** If you establish that an
+existing bullet's finding no longer holds — or never did — remove the line and
+say why in your report. The ledger is a work list, not an archive: an
+annotated bullet still reads as work, and a bullet arguing with itself is
+worse than none. Deleting on disproof is the one case where a reviewer may
+remove a line, and it is the same judgement `/refactor` makes at
+revalidation. Use plain
 `grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
 and `git grep` searches tracked content only, so it reports "not found" for a
 snippet that is sitting right there — the dedupe would pass every time and
@@ -325,5 +333,10 @@ End with:
   local artifact; in the usual case it is gitignored, so writing it moves
   nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
+- **A run that produces no record is not a review.** If you die mid-flight —
+  a rate limit, a crash, a cancelled turn — there is no report and no
+  `last-review.md`, and silence must never be read as a pass. `/release`
+  already treats a missing record as no review; state it here too so nobody
+  fills the gap from memory of a run that never finished.
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -46,12 +46,24 @@ at the current HEAD SHA.
   even for a finding you are certain about. Report it. The only files you may
   write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
   delete) and `.claude/remember/last-review.md` (overwrite; the review record
-  described at the end of this file). Re-run `git status --porcelain` before
-  you report: it must be empty or list only those paths — anything else, say
-  what changed. That turns "it never edits" from a claim into a checked
-  fact.
+  described at the end of this file).
+- **Prove it with two checks, because neither sees what the other does.**
+  `git status --porcelain`, at start and again before you report, proves no
+  **tracked** file changed — that is the "never edits code" guarantee, and it
+  is the one that matters. It cannot police your own two writes: `.claude/`
+  is normally gitignored, so porcelain stays empty whether you wrote the
+  allowed files, wrote nothing, or overwrote `MEMORY.md`. `git status
+  --ignored` does not close it either — it collapses to `!! .claude/`, the
+  directory, not the files. So also take `md5sum .claude/remember/*` before
+  you start and again before you report, and show the comparison: only
+  `fix-ledger.md` and `last-review.md` may differ.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
+
+**The orchestrator runs this check before spawning anyone**, so a dirty tree
+costs no worker; the worker then re-runs it as its own first act, because a
+review that takes the tree's state on trust is the thing this command exists
+not to do. Both, not either.
 
 **Before resolving anything, run `git status --porcelain`.** If it prints any
 line — modified, staged, or untracked — **stop and report it**. Say all three
@@ -201,7 +213,8 @@ including in a doc or spec. But prose is not automatically harmless: in a repo
 whose deliverable *is* a specification, a **normative requirement stated two
 incompatible ways** is a reproduced defect, because two conforming
 implementations built from it diverge. Judge by whether a behaviour changes,
-not by whether the file holds code. A finding already dismissed with evidence in this project's stash
+not by whether the file holds code — and judge it **per finding, not per
+repo**, since a diff mixing code and specification is the normal case. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -11,9 +11,11 @@ reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
 Only **Critical** and **High** findings block the merge. Everything else is
-appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
-committed, cumulative list that `/refactor` (no arguments) works through
-between features. The report is blockers plus the ledger count, so a review
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a local,
+cumulative list, living beside `MEMORY.md`, that `/refactor` (no arguments)
+works through between features. Like its neighbours it is a private working
+artifact, usually gitignored; it persists across reviews, it is not a
+deliverable. The report is blockers plus the ledger count, so a review
 converges instead of surfacing fresh nits every run. This command never runs
 `/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
 
@@ -222,8 +224,9 @@ End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
   tree clean at start; at exit clean or `fix-ledger.md` only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
-  add: "N fixes waiting — run `/refactor` between features." The orchestrator
-  commits the ledger; `/release` accepts a ledger-only commit after the review.
+  add: "N fixes waiting — run `/refactor` between features." The ledger is a
+  local artifact; in the usual case it is gitignored, so writing it moves
+  nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -104,6 +104,14 @@ its exit code.
   "temporary" names, abandoned feature flags.
 - **Correctness.** Edge cases, error handling, type / contract violations,
   broken invariants.
+- **State ownership.** Two or more functions assigning the same field, flag, or
+  view property. A finding on its own — no failing case required. `git grep`
+  every assignment to that name repo-wide, not just in the diff; the second
+  writer is usually in a file the diff never touched. Name both writers with
+  `file:line` — an unnamed second writer is a hunch, not a finding. Count
+  ordering, not just writers: a write arriving from a callback, thread, or
+  lifecycle event is the dangerous one, and one app writer racing a framework
+  one still counts as two.
 - **Performance.** N+1, blocking calls in hot paths, unbounded loops, indexes
   the diff actually touches.
 - **Test quality, not just test presence.** For every test the diff adds or

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -95,12 +95,23 @@ Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
 
-**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
-Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
-blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
-**not** re-judged. A full re-read of an already-reviewed branch produces fresh
-findings every time and never converges. The range form still ends at HEAD,
-so `/release`'s precondition is satisfied.
+**Re-review after fixes: read `.claude/remember/last-review.md` first.** Its
+`sha:` line is the previously-reviewed commit and its `blockers:` list is what
+you owe an answer on — take both from the file, never from the orchestrator's
+recollection, for the same reason `/release` does. Then:
+
+- **`sha:` ≠ HEAD** → this is a re-review. Target the range
+  `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
+  re-verifies each recorded blocker as fixed, unfixed, or dismissed with a
+  reason. The rest of the branch is **not** re-judged: a full re-read of an
+  already-reviewed branch produces fresh findings every run and never
+  converges. The range still ends at HEAD, so `/release`'s precondition is
+  satisfied and the new record replaces the old one.
+- **`sha:` = HEAD** → nothing has changed since the last review. Say so and
+  stop; re-running against an identical tree can only produce noise. If the
+  recorded verdict was `blocked`, its blockers are still unfixed by
+  definition — repeat them rather than re-deriving them.
+- **No file** → no prior review to build on. Review the whole branch.
 
 **On a re-review, sweep the open ledger bullets for liveness first.** Their
 anchors may sit in the part of the branch you are no longer reading, and the

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -42,12 +42,14 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits — one exception.** You have no authorization to change code,
-  even for a finding you are certain about. Report it. The **only** file you
-  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
-  or delete). Re-run `git status --porcelain` before you report: it must be
-  empty or list exactly that one path — anything else, say what changed. That
-  turns "it never edits" from a claim into a checked fact.
+- **No edits — two exceptions.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The only files you may
+  write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
+  delete) and `.claude/remember/last-review.md` (overwrite; the review record
+  described at the end of this file). Re-run `git status --porcelain` before
+  you report: it must be empty or list only those paths — anything else, say
+  what changed. That turns "it never edits" from a claim into a checked
+  fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
 
@@ -87,6 +89,12 @@ blockers (fixed / unfixed / dismissed — with reason); the rest of the branch i
 **not** re-judged. A full re-read of an already-reviewed branch produces fresh
 findings every time and never converges. The range form still ends at HEAD,
 so `/release`'s precondition is satisfied.
+
+**On a re-review, sweep the open ledger bullets for liveness first.** Their
+anchors may sit in the part of the branch you are no longer reading, and the
+fix commits you *are* reading can invalidate them. `grep -F` each open
+snippet against its path; report any whose anchor is gone so `/refactor` can
+drop them. Cheap, and it stops dead bullets accumulating unseen.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -185,8 +193,12 @@ Then the findings, ordered most severe first.
 ### 🚨 Critical / High (blocks merge)
 A **reproduced** failure only: a failing test, a broken build, a security
 exposure, or a bug with a written failure scenario you confirmed in stage 3.
-A finding about a spec's or doc's own prose, structure, or style is **never**
-a blocker. A finding already dismissed with evidence in this project's stash
+A finding about **style, wording or structure** is **never** a blocker —
+including in a doc or spec. But prose is not automatically harmless: in a repo
+whose deliverable *is* a specification, a **normative requirement stated two
+incompatible ways** is a reproduced defect, because two conforming
+implementations built from it diverge. Judge by whether a behaviour changes,
+not by whether the file holds code. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 
@@ -208,6 +220,12 @@ missing):
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
+**A ledger bullet's failure scenario is subject to stage 3 like any other.**
+Ledger items skip the report, so they are easy to skip verifying too, and an
+unverified consequence written in the bullet's voice reads as established
+fact to whoever fixes it later. Either confirm it, or prefix the scenario
+with `UNVERIFIED:` so `/refactor` retests before acting.
+
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
@@ -227,9 +245,24 @@ Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
 each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
+**Write the review record** to `.claude/remember/last-review.md`, overwriting
+it. `/release` reads this file; a SHA that lives only in a chat message is
+gone after a compaction or a handover, and the only remaining source is the
+orchestrator — the one party this command already refuses to take a review's
+word from. Exactly these five lines:
+
+```
+sha: <full HEAD sha>
+branch: <branch>
+target: <resolved range or path>
+verdict: <ready | blocked>
+date: <YYYY-MM-DD>
+```
+
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start; at exit clean or `fix-ledger.md` only.**
+  tree clean at start; at exit clean or the two `.claude/remember/` paths
+  only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
   add: "N fixes waiting — run `/refactor` between features." The ledger is a
   local artifact; in the usual case it is gitignored, so writing it moves

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -265,15 +265,45 @@ assumed pass.
 it. `/release` reads this file; a SHA that lives only in a chat message is
 gone after a compaction or a handover, and the only remaining source is the
 orchestrator — the one party this command already refuses to take a review's
-word from. Exactly these five lines:
+word from. **Write it at the end of every run, unconditionally** — not after
+someone decides what to do about it. The information exists now, and the file
+earns its keep only by surviving a compaction, an abandoned session, or a
+handover to someone who never saw the report.
 
 ```
 sha: <full HEAD sha>
 branch: <branch>
 target: <resolved range or path>
+level: <low | medium | high | max>
 verdict: <ready | blocked>
 date: <YYYY-MM-DD>
+coverage: stage1 <ran|NOT RUN>, stage2 <ran|NOT RUN>, stage3 <ran|NOT RUN>
+blockers:
+- <file:line> · <one-sentence claim, no scenario, no suggested fix>
 ```
+
+`blockers: none` when the verdict is ready. One line per blocker and nothing
+more: the reasoning belongs in the report, and the non-blocking findings
+belong in the ledger. This exists so a session that never saw the report can
+learn *what* is blocked, not just *that* something is — otherwise the next
+run rediscovers it by re-reviewing the branch, which is the
+non-convergence this command exists to stop.
+
+`coverage` is recorded because a `ready` from a run whose security stage did
+not execute is not the same fact as one where it did, and the reader of this
+file cannot tell them apart otherwise.
+
+**There is no override field, and no `verdict: overridden`.** A SHA is
+checkable by anyone; consent is not, so a consent line in a file is forgeable
+by whatever writes the file — and a persisted override is reusable, silently
+covering the next release as well as this one. Releasing over a blocked
+review is a live decision made at `/release`'s hand-back, in conversation.
+
+**Nothing clears this file.** It is overwritten whole on the next run, and the
+`sha:` line is what expires it: fix something, commit, and the recorded hash
+no longer matches HEAD, so the gate reports *stale* and asks for a
+re-review rather than *blocked*. A blocked verdict can only persist while HEAD
+does not move — which means nothing was fixed, which is the correct outcome.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -118,7 +118,10 @@ judging.
 not a fact to accept. Branches are commonly AI-authored now — including the
 fixes to the fixes — so a review that trusts the message is reviewing prose.
 Run the test suite and the typecheck/build yourself and cite the command and
-its exit code.
+its exit code. Read that code off the bare command (`cmd > /tmp/out 2>&1;
+e=$?`), never off a pipeline — `$?` after a pipe is the last element's
+status, so piping into `tail` reports `0` for a suite that failed. `/ship`
+carries the reproduction.
 
 - **Bugs needing a fix.** Logic errors, off-by-one, null/undefined paths,
   races, wrong defaults, broken edge cases.

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -10,6 +10,13 @@ audit** — followed by an adversarial verify pass. It **never edits code**: it
 reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
+Only **Critical** and **High** findings block the merge. Everything else is
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
+committed, cumulative list that `/refactor` (no arguments) works through
+between features. The report is blockers plus the ledger count, so a review
+converges instead of surfacing fresh nits every run. This command never runs
+`/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
+
 Run this **before** `/release`. `/release` will refuse to run without a review
 at the current HEAD SHA.
 
@@ -33,9 +40,11 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits.** You have no authorization to change code, even for a finding
-  you are certain about. Report it. Re-run `git status --porcelain` before you
-  report and confirm it is still empty — if it is not, say what changed. That
+- **No edits — one exception.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The **only** file you
+  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
+  or delete). Re-run `git status --porcelain` before you report: it must be
+  empty or list exactly that one path — anything else, say what changed. That
   turns "it never edits" from a claim into a checked fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
@@ -69,6 +78,13 @@ With a clean tree, interpret `$ARGUMENTS` in this order:
 Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
+
+**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
+Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
+blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
+**not** re-judged. A full re-read of an already-reviewed branch produces fresh
+findings every time and never converges. The range form still ends at HEAD,
+so `/release`'s precondition is satisfied.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -164,21 +180,50 @@ verdict first, then repeat it at the end.
 
 Then the findings, ordered most severe first.
 
-### 🚨 Critical (blocks merge)
-### ⚠️ Warnings (should fix)
-### 💡 Suggestions (nice to have)
+### 🚨 Critical / High (blocks merge)
+A **reproduced** failure only: a failing test, a broken build, a security
+exposure, or a bug with a written failure scenario you confirmed in stage 3.
+A finding about a spec's or doc's own prose, structure, or style is **never**
+a blocker. A finding already dismissed with evidence in this project's stash
+or memory cannot come back at a higher severity without **new** evidence —
+check before escalating.
 
-Each finding: **Location** (`file:line`) · **What's wrong** · **Failure
-scenario** (inputs/state → result) · **Why it matters** · **Suggested fix**
-(described, not applied) · **Verdict** (confirmed / uncertain).
+### Ledger (non-blocking — medium / low)
+Not in the report. **Append** each one as a single bullet to
+`.claude/remember/fix-ledger.md` (create the file with the header below if
+missing):
 
-Then a coverage line: stage 1 at level `<level>`, stage 2 full — each `ran ✓/✗`
-with its evidence. A stage you did not actually run is a **✗**, never an
+```
+# Fix ledger
+> Non-blocking review findings. One bullet per item. Delete the bullet when
+> fixed, or when its anchor no longer exists. Written by /branch-review;
+> consumed by /refactor (ledger mode).
+
+- `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
+  scenario · YYYY-MM-DD @ <short sha>
+```
+
+The **snippet is the anchor**: 20–60 verbatim characters from the line,
+unique enough for `git grep -F` to find it after lines shift. No line
+numbers, no TODO comments in code — the ledger is the single writer. Before
+appending, `git grep -F` the snippet in the ledger itself; if it is already
+there, skip it. Do not touch existing bullets.
+
+Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
+**Failure scenario** (inputs/state → result) · **Why it matters** ·
+**Suggested fix** (described, not applied) · **Verdict** (confirmed /
+uncertain).
+
+Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
+each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start and at exit.**
+  tree clean at start; at exit clean or `fix-ledger.md` only.**
+- **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
+  add: "N fixes waiting — run `/refactor` between features." The orchestrator
+  commits the ledger; `/release` accepts a ledger-only commit after the review.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/droid/commands/refactor.md
+++ b/packages/droid/commands/refactor.md
@@ -57,7 +57,9 @@ Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 verification, HITL gates) still applies; this section only says what to
 refactor and how to close each item.
 
-1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+1. **Tree must be clean and not on `main`.** The orchestrator runs this check
+   before spawning the worker, so a dirty tree costs no worker; the worker
+   then re-runs it as its own first act. `git status --porcelain` non-empty
    → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
 2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
 3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F

--- a/packages/droid/commands/refactor.md
+++ b/packages/droid/commands/refactor.md
@@ -7,6 +7,50 @@ allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(
 ---
 Refactor $ARGUMENTS.
 
+## Guardrails
+- **Spawn a worker and explicitly select your tool's mid tier.** State the
+  tier on the spawn — do not omit it and rely on a default. An omitted tier
+  inherits the *parent's* tier, which is not the same thing as the balanced
+  one. Pick the judgment-capable tier that is cheaper and faster than your top
+  reasoning tier. **Not the cheapest/fastest tier**: on judgment work it
+  measurably degrades (misclassification rates several times higher). Choose by
+  tier, not by a vendor model name copied from this file — names drift, and
+  this command ships to several tools. Fall back to running inline if your tool
+  has no subagent mechanism.
+- **Escalate, never assume.** Anything you cannot decide, cannot verify, or
+  that this spec does not cover → **stop and report it to the orchestrator**
+  (the main session). Never improvise, never widen scope, never fix a side
+  issue you noticed along the way.
+- **The worker does the work itself — no delegation.** The fixer must **not**
+  spawn subagents of its own. Every edit it reports, and every test run it
+  cites, has to be one it made or ran with its own tool calls: a relayed "I
+  fixed it and the suite is green" from a sub-worker is hearsay, and this
+  command's whole output is the claim that a change landed and the tests still
+  pass. A fix that delegates its work is a report about a report.
+- **The HITL gates below belong to the orchestrator, not the worker.** A
+  subagent cannot hold a conversation with the user, so it cannot run a gate
+  that ends in *stop and ask*. When one trips — a failing test, a crossed
+  public API boundary, a change bigger than the bullet asked for — the worker
+  **stops there and hands the situation back**, with the options and its
+  reasoning but no choice made. The orchestrator asks. A worker that picks
+  revert / patch / update-test on the user's behalf has answered a question it
+  was never allowed to ask.
+- **Edit only what a surviving bullet names.** Ledger mode's scope is the
+  bullets that survive revalidation, one change per bullet — not the
+  neighbouring code, not the formatting, not a second finding noticed on the
+  way past. Anything else goes back to the orchestrator to become a new
+  bullet.
+- **Prove the blast radius with two checks, because neither sees what the
+  other does.** `git status --porcelain` at exit must list only files a
+  surviving bullet named — that is this command's scope guarantee, and unlike
+  `/branch-review` it is not expected to be empty. It cannot police the
+  memory directory: `.claude/` is normally gitignored, so porcelain stays
+  empty whether you deleted a fixed bullet, wrote nothing, or overwrote
+  `MEMORY.md`. So also take `md5sum .claude/remember/*` before you start and
+  again before you report, and show the comparison: only `fix-ledger.md` may
+  differ. `last-review.md` in particular is `/branch-review`'s to write —
+  a fixer that touches it forges the gate that judges its own work.
+
 ## Ledger mode — `$ARGUMENTS` empty
 Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 `/branch-review` has accumulated. Everything below (goals, constraints,

--- a/packages/droid/commands/refactor.md
+++ b/packages/droid/commands/refactor.md
@@ -1,11 +1,33 @@
 ---
 name: refactor
 description: Refactor [code]
-usage: /refactor <code-section>
-argument-hint: [file-or-function]
-allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *)
+usage: /refactor <code-section> | /refactor (no args = fix-ledger mode)
+argument-hint: [file-or-function, or empty for the fix ledger]
+allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *), Bash(git grep *), Bash(git status *), Bash(git rev-parse *), Bash(git switch *)
 ---
 Refactor $ARGUMENTS.
+
+## Ledger mode — `$ARGUMENTS` empty
+Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
+`/branch-review` has accumulated. Everything below (goals, constraints,
+verification, HITL gates) still applies; this section only says what to
+refactor and how to close each item.
+
+1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+   → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
+2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
+3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F
+   "<snippet>" -- <path>`. **No hit → delete the bullet** and list it as
+   "cleaned by other work". Hit → re-read the surrounding code; if the finding
+   no longer holds, delete the bullet with a one-line reason. What survives is
+   the work list.
+4. **Fix the survivors, one bullet per change**, under the constraints below.
+   Delete each bullet as its fix lands. A fix that turns out to need a
+   behaviour change is not a refactor — leave the bullet, note it in the report.
+5. Run the tests as described below. Then report: **fixed / dropped / left**
+   with the reason per left item, and the remaining bullet count.
+6. Say plainly: **commit, then run `/branch-review`** on this branch — ledger
+   mode is a fixer, not a review, and its diff gets the ordinary gate.
 
 ## Goals
 - Reduce complexity

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -75,6 +75,9 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`coverage:` naming any stage `NOT RUN`** → **stop**. A `ready` from a run
+  that skipped the security stage is not the same fact as one that did not,
+  and this line is the only place the difference is visible to you.
 - **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
   Read that line as mechanically as the `sha:` one. A matching SHA proves a
   review ran here; it says nothing about what the review concluded, and

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -80,9 +80,14 @@ that predates this file's introduction has no record, so it does not count.
 
 This phase runs **before** `/release` writes anything, so the docs-and-bump
 commit it makes later cannot invalidate the review it just checked. That
-commit is also where a doc-only ledger item is cheapest to close: correcting
-a stale line during the docs sweep costs nothing, where fixing it on its own
-means a commit, a stale review, and a re-review for one word.
+If Phase 2's docs sweep happens to correct a line that a fix-ledger bullet
+also names, that is ordinary sweep work — the doc changed with the feature,
+so it was already yours to update. **Do not delete the bullet.** `/refactor`
+is the only deleter, and its revalidation will drop that bullet on its next
+run when it finds the finding no longer holds. Deleting it here would make
+`/release` a second writer on state that has exactly one owner, and the whole
+value of the ledger's one-append-one-delete split is that it stays readable
+as a log.
 
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -67,12 +67,11 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically, and only in repos that track the
-  ledger** (it is normally gitignored, in which case it never reaches this
-  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
-  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
-  file is the review's own output, not a change to the code it reviewed. Any
-  other path in that list → stale.
+  **No exceptions — including the fix ledger.** It is normally gitignored, so
+  appending to it moves nothing and this never comes up. A repo that tracks
+  `.claude/` instead will see a ledger commit land after the review and make
+  it stale. That is the rule working, not a case to carve out: re-review, or
+  leave the ledger uncommitted until after the release.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -75,6 +75,12 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
+  Read that line as mechanically as the `sha:` one. A matching SHA proves a
+  review ran here; it says nothing about what the review concluded, and
+  leaving the conclusion to the orchestrator's recollection restores exactly
+  the unverified claim this file replaced. Only `verdict: ready` with a
+  matching SHA is a pass.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -67,6 +67,10 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
+  **One carve-out, checked mechanically:** if `git diff --name-only
+  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
+  nothing else, the review stands — the ledger is the review's own output,
+  committed after it by design. Any other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -160,15 +160,27 @@ orchestrator can run them on the user's named go:
 > Ready when you are:
 > 1. `git push -u origin <branch>`
 > 2. `gh pr create` into `main`
-> 3. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
+> 3. `gh pr checks <pr> --watch` — **merge only on green.** Every gate before
+>    this one ran on the same machine; CI is the only differently-configured
+>    instrument in the chain, and this is the first time it sees the branch.
+>    A test that passes locally because of a path, a fixture, or a tool that
+>    exists only on your box fails here and nowhere earlier. Read the exit
+>    code off the bare command. Red → stop, fix, re-review, and start again.
+> 4. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
 >    owner-authorized admin merge on a solo repo). **Keep `--squash`** — `gh`
 >    requires an explicit merge-method flag (`--squash` / `--merge` /
 >    `--rebase`); drop it and the command will not squash-merge.
-> 4. `git tag vX.Y.Z` on `main` and push the tag
-> 5. Publish **if this project has a publish path** (e.g.
+> 5. `git tag vX.Y.Z` on `main` and push the tag
+> 6. Publish **if this project has a publish path** (e.g.
 >    `gh workflow run publish.yml`) — manual by design
-> 6. Verify it is actually live (`npm view <pkg> version`, and the published
+> 7. Verify it is actually live (`npm view <pkg> version`, and the published
 >    tarball's contents), not the working tree
+
+**Every exit code in this sequence is read off the bare command, including
+the ones you type yourself.** `/ship`'s rule is not just for the worker: a
+pipeline reports its last element's status, so `gh run watch --exit-status |
+tail -2; echo $?` prints `0` for a failed run. That has already turned a red
+CI into a green reading in a real release.
 
 Final line: **Cut ✅ (vX.Y.Z — ready to push)** or **Blocked 🛑** with the
 specific reason.

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -78,6 +78,12 @@ that predates this file's introduction has no record, so it does not count.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 
+This phase runs **before** `/release` writes anything, so the docs-and-bump
+commit it makes later cannot invalidate the review it just checked. That
+commit is also where a doc-only ledger item is cheapest to close: correcting
+a stale line during the docs sweep costs nothing, where fixing it on its own
+means a commit, a stale review, and a re-review for one word.
+
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -67,10 +67,12 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically:** if `git diff --name-only
-  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
-  nothing else, the review stands — the ledger is the review's own output,
-  committed after it by design. Any other path in that list → stale.
+  **One carve-out, checked mechanically, and only in repos that track the
+  ledger** (it is normally gitignored, in which case it never reaches this
+  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
+  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
+  file is the review's own output, not a change to the code it reviewed. Any
+  other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/droid/commands/release.md
+++ b/packages/droid/commands/release.md
@@ -56,11 +56,14 @@ separate command that must have run first.
 A review must have run on this branch **at the current HEAD SHA**.
 
 **Compare the SHAs yourself; do not settle for an answer.** Run `git rev-parse
-HEAD` and compare it against the SHA the review recorded — `/branch-review`
-ends with `Reviewed at HEAD <sha>`. Asking the orchestrator "did a review run?"
-puts the question to the one party with an incentive to say yes, so its word is
-not evidence: obtain the review's own recorded SHA and match the two strings.
-**No recorded SHA to compare = no review**, never a pass.
+HEAD` and compare it against the `sha:` line in
+`.claude/remember/last-review.md`, which `/branch-review` writes. Asking the
+orchestrator "did a review run?" puts the question to the one party with an
+incentive to say yes, so its word is not evidence — and neither is a SHA
+quoted from a chat message, which is the same claim in another costume and is
+gone after a compaction or a handover. Read the file; match the two strings.
+**No such file, or no `sha:` line in it = no review**, never a pass. A review
+that predates this file's introduction has no record, so it does not count.
 
 - **No review**, or no recorded SHA obtainable → **stop**: "No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."

--- a/packages/droid/commands/remember.md
+++ b/packages/droid/commands/remember.md
@@ -380,7 +380,8 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENTS.md lacks a given pair, append it at the
-     end; if no AGENTS.md exists, create one containing whichever section(s) apply.
+     end; if a given pair already exists, replace its content in place; if no AGENTS.md
+     exists, create one containing whichever section(s) apply.
    - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
      block above is what to write when creating it, not a template to re-impose every run.
      Users trim this section deliberately (a pointer-only variant is common), and rewriting

--- a/packages/droid/commands/remember.md
+++ b/packages/droid/commands/remember.md
@@ -346,11 +346,23 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      inline duplication is needed
    - If `.factory/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
-     — an `@`-reference hot-loads the whole file into every session, and this is a standards
-     guide to consult when designing/building something new, not hot context:
+     markers. Unlike MEMORY.md above, the file itself is **never `@`-referenced** — an
+     `@`-reference hot-loads all ~300 lines into every session, and it is a standards guide
+     to consult when designing/building something new, not hot context. The section carries
+     a path pointer plus exactly two inline rules: the ones that change what you TYPE, which
+     you cannot look up because you do not know you need them. Everything else stays behind
+     the pointer. Write the section verbatim, rules first:
      ```
      <!-- AGENT_RULES:START -->
+     **One writer per piece of state.** One function assigns each field; everything else
+     calls it. Grep who writes it before you write it — and if a write can land from a
+     callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+     **Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you
+     pass: if it's inside or affects the code you're already changing and the fix changes
+     no behavior, fix it and say so — otherwise report it and say what it costs to leave
+     it. A problem you don't fix goes in the report, never in a comment.
+
      Standards guide (read when designing/building something new, not hot context):
      .factory/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->

--- a/packages/droid/commands/remember.md
+++ b/packages/droid/commands/remember.md
@@ -133,6 +133,14 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      Re-processing a stash whose episode is already filed must not create a near-duplicate
      pair. Every older episode is **folded, then deleted**: its lesson becomes a fact (handed
      to the rewrite above); the narrative is removed. No archive — git has the history.
+     **Specify the operation once.** The keep-10 rule is the rule; the set to remove is
+     *derived* from it, never supplied alongside it as a second list. Given both, an agent
+     applies both and removes their union — observed in the field: a run told to keep 10 and
+     handed a 5-entry delete list removed 7, and the 2 extras were never folded, so one
+     lesson left memory with nothing carrying it. **No episode is removed whose lesson has
+     not been folded into a fact first**, and the two sets must match: state the count
+     before, the count after, and name each episode removed. Removed-but-not-folded is a
+     defect to report, not a tidy-up.
    - **Antigens section**: only update from friction output (step 4)
    - Write merged result to `.factory/remember/MEMORY.md` in the format under step 5.
 
@@ -276,7 +284,11 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
        recurrence; a single occurrence has none to track yet. Friction re-scans every
        session log every run, so a later run matches it back to 2+ sessions and seeds it
        then — this does not change matching against an EXISTING entry, which is recurrence
-       regardless of the matching cluster's own session count.
+       regardless of the matching cluster's own session count. **A match is not an
+       increment.** Whether it counts as a new conversation is decided in 4c by
+       `friction.cjs count`, which is a no-op when that session hash is already stored — so
+       several matches against one entry routinely produce zero increments, and that is
+       correct, not a miscount.
      - For `new:<theme>` groups with no ledger match: distinct conversations = distinct
        cluster indices in the group (within one classify batch, no two cluster indices
        share a session hash). `sessions < 2` → writes nothing. `sessions >= 2` → new entry,
@@ -367,9 +379,17 @@ Reads all raw material (`.factory/stash/*.md` + `.factory/remember/friction/anti
      .factory/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
-   - Each marker pair is independent: if AGENTS.md already has a given pair, replace the
-     section between them; if not, append it at the end; if no AGENTS.md exists, create one
-     containing whichever section(s) apply
+   - Each marker pair is independent: if AGENTS.md lacks a given pair, append it at the
+     end; if no AGENTS.md exists, create one containing whichever section(s) apply.
+   - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
+     block above is what to write when creating it, not a template to re-impose every run.
+     Users trim this section deliberately (a pointer-only variant is common), and rewriting
+     it silently re-adds text they removed, on every single run, forever. Observed in the
+     field: a run restored the inline rules into a AGENTS.md whose owner had cut them, and
+     the edit had to be reverted by hand. This matches how `AGENT_RULES.md` itself is
+     handled — bootstrapped once, never overwritten after.
+   - If an existing pair is present but its **path pointer** is missing or wrong, that is
+     load-bearing: **report it and stop**, do not silently rewrite the section around it.
 
    ```markdown
    # Project Memory

--- a/packages/droid/commands/remember/AGENT_RULES.md
+++ b/packages/droid/commands/remember/AGENT_RULES.md
@@ -105,11 +105,14 @@ Before adding any external dependency, all of these must be true:
 
 - **Open-source only.** Always use open-source solutions. No vendor lock-in
 - **Lightweight over complex.** If two solutions solve the same problem, use the one with fewer moving parts, fewer dependencies, and less configuration
-- **Every line must have a purpose.** No speculative code, no "might need this later", no abstractions for one use case
+- **Every line earns its place.** If you can't say what breaks when it's deleted, delete it. No speculative code, no "might need this later", no abstractions for one use case. One function, one concern, one owner — small blocks beat spaghetti
 - **Simple > clever.** Readable code that a junior can follow beats elegant code that requires a PhD to debug
+- **One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it. Ownership says *where*, not *when* — if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh
+- **Split the decision from the machinery.** A branch whose outcome matters, tangled with a framework, IO, or UI object, moves into a pure function; the framework class applies the result. Extract to pin a branch, not to raise coverage — a one-line delegation in its own file buys a test that cannot fail
+- **Claims in comments must be checkable.** "The only place that writes X" is a claim — run the grep first, and expect the next reader to re-run it. A name search proves an edge exists, never that one doesn't
 - **Containerize only when necessary.** Start with a virtualenv or bare metal. Docker adds value for deployment parity and isolation — not for running a script
 - **Responsive web UI is mandatory in dev projects.** Any web UI must be usable on mobile by default — fluid layouts, viewport meta tag, breakpoints for narrow screens, no horizontal scroll. Test in DevTools device emulation before declaring a UI task done. POCs are exempt (validate the idea first), but the moment a POC graduates to a real project this becomes a hard requirement
-- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created — leave pre-existing dead code alone unless asked. Every changed line should trace directly to the request
+- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created. Dead code, nits, bugs you pass on the way: if it's inside or affects the code you're already changing, and the fix changes no behavior, fix it and say so. Otherwise report it — say what it costs to leave it. "It would be nicer" is not a cost. Every changed line traces to the request or to a fix you named
 
 ### Red Flags — Stop and Flag These
 - Over-engineering simple problems
@@ -120,6 +123,8 @@ Before adding any external dependency, all of these must be true:
 - POC-ing only the easy part while hand-waving the risky mechanism, or claiming a cost ("cheap"/"fast"/"constant") you never measured
 - Authoring a fixture/corpus that *guarantees* the result (a test that can't return the negative), or trusting a degenerate-looking number without auditing the harness for confounds — use real uncrafted data; the test must be able to fail
 - Fitting a POC to pass (narrowed input, moved threshold, shrunk scope) instead of reporting the failure; starting module N+1 while module N is unproven
+
+A problem you see and don't fix goes in the report, never in a comment. Comments are where findings go to be forgotten.
 
 ---
 
@@ -291,7 +296,11 @@ Copy this to any project's AGENTS.md. These are mandatory rules, not suggestions
 
 **Lightweight over complex.** Fewer moving parts, fewer deps, less config. Express over NestJS, Flask over Django, unless the project genuinely needs the framework. Simple > clever. Readable > elegant.
 
-**Open-source only.** No vendor lock-in. Every line of code must have a purpose — no speculative code, no premature abstractions.
+**Open-source only.** No vendor lock-in. Every line of code earns its place — if you can't say what breaks when it's deleted, delete it. No speculative code, no premature abstractions.
+
+**One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it — and if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+**Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you pass: if it's inside or affects the code you're already changing and the fix changes no behavior, fix it and say so — otherwise report it and say what it costs to leave it. A problem you don't fix goes in the report, never in a comment.
 
 **Responsive web UI is mandatory.** Any web UI must work on mobile by default — fluid layouts, viewport meta, breakpoints, no horizontal scroll. Verify in DevTools device emulation before claiming a UI task is done. POCs exempt; real projects are not.
 

--- a/packages/droid/commands/ship.md
+++ b/packages/droid/commands/ship.md
@@ -20,6 +20,22 @@ its exit code**. A check you did not run is a **fail**, never a pass. **N/A
 requires a stated reason** ("no build script in `package.json`") — N/A must
 never stand in for "didn't get to it."
 
+**Capture the exit code of the command itself, never of a pipeline.** Run the
+bare command, then read `$?` on the next line:
+
+```
+node "$f" > /tmp/out 2>&1; e=$?
+```
+
+`$?` after a pipe is the *last element's* status, so the common shape
+`out=$(cmd 2>&1 | tail -1); echo "exit=$?"` reports `tail`'s success — `0` —
+for a suite that exited `2`. Reproduced: a check printing "exit 2:
+prerequisites missing" was recorded as a pass by exactly that loop. Nor does
+`${PIPESTATUS[0]}` rescue it inside a command substitution; it is empty by
+the time you read it. This is the rule the whole gate rests on, and the
+piped form is the natural way to write a multi-suite loop, so it fails
+silently and in the unsafe direction.
+
 ## Checklist
 - [ ] **Tests pass** — run the project's real test command (`npm test`,
       `pytest`, `go test ./...`, `cargo test`, `make test`).

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -200,6 +200,9 @@ missing):
 > Non-blocking review findings. One bullet per item. Delete the bullet when
 > fixed, or when its anchor no longer exists. Written by /branch-review;
 > consumed by /refactor (ledger mode).
+>
+> A bullet's path may be a glob when the same finding exists in every kit —
+> `git grep -F "<snippet>" -- <path>` accepts one.
 
 - `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
   scenario · YYYY-MM-DD @ <short sha>
@@ -208,8 +211,12 @@ missing):
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
-appending, `git grep -F` the snippet in the ledger itself; if it is already
-there, skip it. Do not touch existing bullets.
+appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
+if it is already there, skip it. Do not touch existing bullets. Use plain
+`grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
+and `git grep` searches tracked content only, so it reports "not found" for a
+snippet that is sitting right there — the dedupe would pass every time and
+the same finding would be appended on every run.
 
 Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
 **Failure scenario** (inputs/state → result) · **Why it matters** ·

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -257,7 +257,15 @@ The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
 appending, dedupe with **plain `grep -F "<snippet>" .claude/remember/fix-ledger.md`**;
-if it is already there, skip it. Do not touch existing bullets. Use plain
+if it is already there, skip it. Do not touch existing bullets.
+
+**A bullet you disprove is deleted, not annotated.** If you establish that an
+existing bullet's finding no longer holds — or never did — remove the line and
+say why in your report. The ledger is a work list, not an archive: an
+annotated bullet still reads as work, and a bullet arguing with itself is
+worse than none. Deleting on disproof is the one case where a reviewer may
+remove a line, and it is the same judgement `/refactor` makes at
+revalidation. Use plain
 `grep`, never `git grep`, on the ledger: the ledger is normally gitignored,
 and `git grep` searches tracked content only, so it reports "not found" for a
 snippet that is sitting right there — the dedupe would pass every time and
@@ -325,5 +333,10 @@ End with:
   local artifact; in the usual case it is gitignored, so writing it moves
   nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
+- **A run that produces no record is not a review.** If you die mid-flight —
+  a rate limit, a crash, a cancelled turn — there is no report and no
+  `last-review.md`, and silence must never be read as a pass. `/release`
+  already treats a missing record as no review; state it here too so nobody
+  fills the gap from memory of a run that never finished.
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -46,12 +46,24 @@ at the current HEAD SHA.
   even for a finding you are certain about. Report it. The only files you may
   write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
   delete) and `.claude/remember/last-review.md` (overwrite; the review record
-  described at the end of this file). Re-run `git status --porcelain` before
-  you report: it must be empty or list only those paths — anything else, say
-  what changed. That turns "it never edits" from a claim into a checked
-  fact.
+  described at the end of this file).
+- **Prove it with two checks, because neither sees what the other does.**
+  `git status --porcelain`, at start and again before you report, proves no
+  **tracked** file changed — that is the "never edits code" guarantee, and it
+  is the one that matters. It cannot police your own two writes: `.claude/`
+  is normally gitignored, so porcelain stays empty whether you wrote the
+  allowed files, wrote nothing, or overwrote `MEMORY.md`. `git status
+  --ignored` does not close it either — it collapses to `!! .claude/`, the
+  directory, not the files. So also take `md5sum .claude/remember/*` before
+  you start and again before you report, and show the comparison: only
+  `fix-ledger.md` and `last-review.md` may differ.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
+
+**The orchestrator runs this check before spawning anyone**, so a dirty tree
+costs no worker; the worker then re-runs it as its own first act, because a
+review that takes the tree's state on trust is the thing this command exists
+not to do. Both, not either.
 
 **Before resolving anything, run `git status --porcelain`.** If it prints any
 line — modified, staged, or untracked — **stop and report it**. Say all three
@@ -201,7 +213,8 @@ including in a doc or spec. But prose is not automatically harmless: in a repo
 whose deliverable *is* a specification, a **normative requirement stated two
 incompatible ways** is a reproduced defect, because two conforming
 implementations built from it diverge. Judge by whether a behaviour changes,
-not by whether the file holds code. A finding already dismissed with evidence in this project's stash
+not by whether the file holds code — and judge it **per finding, not per
+repo**, since a diff mixing code and specification is the normal case. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -11,9 +11,11 @@ reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
 Only **Critical** and **High** findings block the merge. Everything else is
-appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
-committed, cumulative list that `/refactor` (no arguments) works through
-between features. The report is blockers plus the ledger count, so a review
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a local,
+cumulative list, living beside `MEMORY.md`, that `/refactor` (no arguments)
+works through between features. Like its neighbours it is a private working
+artifact, usually gitignored; it persists across reviews, it is not a
+deliverable. The report is blockers plus the ledger count, so a review
 converges instead of surfacing fresh nits every run. This command never runs
 `/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
 
@@ -222,8 +224,9 @@ End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
   tree clean at start; at exit clean or `fix-ledger.md` only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
-  add: "N fixes waiting — run `/refactor` between features." The orchestrator
-  commits the ledger; `/release` accepts a ledger-only commit after the review.
+  add: "N fixes waiting — run `/refactor` between features." The ledger is a
+  local artifact; in the usual case it is gitignored, so writing it moves
+  nothing and leaves HEAD untouched.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -104,6 +104,14 @@ its exit code.
   "temporary" names, abandoned feature flags.
 - **Correctness.** Edge cases, error handling, type / contract violations,
   broken invariants.
+- **State ownership.** Two or more functions assigning the same field, flag, or
+  view property. A finding on its own — no failing case required. `git grep`
+  every assignment to that name repo-wide, not just in the diff; the second
+  writer is usually in a file the diff never touched. Name both writers with
+  `file:line` — an unnamed second writer is a hunch, not a finding. Count
+  ordering, not just writers: a write arriving from a callback, thread, or
+  lifecycle event is the dangerous one, and one app writer racing a framework
+  one still counts as two.
 - **Performance.** N+1, blocking calls in hot paths, unbounded loops, indexes
   the diff actually touches.
 - **Test quality, not just test presence.** For every test the diff adds or

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -95,12 +95,23 @@ Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
 
-**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
-Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
-blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
-**not** re-judged. A full re-read of an already-reviewed branch produces fresh
-findings every time and never converges. The range form still ends at HEAD,
-so `/release`'s precondition is satisfied.
+**Re-review after fixes: read `.claude/remember/last-review.md` first.** Its
+`sha:` line is the previously-reviewed commit and its `blockers:` list is what
+you owe an answer on — take both from the file, never from the orchestrator's
+recollection, for the same reason `/release` does. Then:
+
+- **`sha:` ≠ HEAD** → this is a re-review. Target the range
+  `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
+  re-verifies each recorded blocker as fixed, unfixed, or dismissed with a
+  reason. The rest of the branch is **not** re-judged: a full re-read of an
+  already-reviewed branch produces fresh findings every run and never
+  converges. The range still ends at HEAD, so `/release`'s precondition is
+  satisfied and the new record replaces the old one.
+- **`sha:` = HEAD** → nothing has changed since the last review. Say so and
+  stop; re-running against an identical tree can only produce noise. If the
+  recorded verdict was `blocked`, its blockers are still unfixed by
+  definition — repeat them rather than re-deriving them.
+- **No file** → no prior review to build on. Review the whole branch.
 
 **On a re-review, sweep the open ledger bullets for liveness first.** Their
 anchors may sit in the part of the branch you are no longer reading, and the

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -42,12 +42,14 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits — one exception.** You have no authorization to change code,
-  even for a finding you are certain about. Report it. The **only** file you
-  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
-  or delete). Re-run `git status --porcelain` before you report: it must be
-  empty or list exactly that one path — anything else, say what changed. That
-  turns "it never edits" from a claim into a checked fact.
+- **No edits — two exceptions.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The only files you may
+  write are `.claude/remember/fix-ledger.md` (append bullets; never rewrite or
+  delete) and `.claude/remember/last-review.md` (overwrite; the review record
+  described at the end of this file). Re-run `git status --porcelain` before
+  you report: it must be empty or list only those paths — anything else, say
+  what changed. That turns "it never edits" from a claim into a checked
+  fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
 
@@ -87,6 +89,12 @@ blockers (fixed / unfixed / dismissed — with reason); the rest of the branch i
 **not** re-judged. A full re-read of an already-reviewed branch produces fresh
 findings every time and never converges. The range form still ends at HEAD,
 so `/release`'s precondition is satisfied.
+
+**On a re-review, sweep the open ledger bullets for liveness first.** Their
+anchors may sit in the part of the branch you are no longer reading, and the
+fix commits you *are* reading can invalidate them. `grep -F` each open
+snippet against its path; report any whose anchor is gone so `/refactor` can
+drop them. Cheap, and it stops dead bullets accumulating unseen.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -185,8 +193,12 @@ Then the findings, ordered most severe first.
 ### 🚨 Critical / High (blocks merge)
 A **reproduced** failure only: a failing test, a broken build, a security
 exposure, or a bug with a written failure scenario you confirmed in stage 3.
-A finding about a spec's or doc's own prose, structure, or style is **never**
-a blocker. A finding already dismissed with evidence in this project's stash
+A finding about **style, wording or structure** is **never** a blocker —
+including in a doc or spec. But prose is not automatically harmless: in a repo
+whose deliverable *is* a specification, a **normative requirement stated two
+incompatible ways** is a reproduced defect, because two conforming
+implementations built from it diverge. Judge by whether a behaviour changes,
+not by whether the file holds code. A finding already dismissed with evidence in this project's stash
 or memory cannot come back at a higher severity without **new** evidence —
 check before escalating.
 
@@ -208,6 +220,12 @@ missing):
   scenario · YYYY-MM-DD @ <short sha>
 ```
 
+**A ledger bullet's failure scenario is subject to stage 3 like any other.**
+Ledger items skip the report, so they are easy to skip verifying too, and an
+unverified consequence written in the bullet's voice reads as established
+fact to whoever fixes it later. Either confirm it, or prefix the scenario
+with `UNVERIFIED:` so `/refactor` retests before acting.
+
 The **snippet is the anchor**: 20–60 verbatim characters from the line,
 unique enough for `git grep -F` to find it after lines shift. No line
 numbers, no TODO comments in code — the ledger is the single writer. Before
@@ -227,9 +245,24 @@ Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
 each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
+**Write the review record** to `.claude/remember/last-review.md`, overwriting
+it. `/release` reads this file; a SHA that lives only in a chat message is
+gone after a compaction or a handover, and the only remaining source is the
+orchestrator — the one party this command already refuses to take a review's
+word from. Exactly these five lines:
+
+```
+sha: <full HEAD sha>
+branch: <branch>
+target: <resolved range or path>
+verdict: <ready | blocked>
+date: <YYYY-MM-DD>
+```
+
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start; at exit clean or `fix-ledger.md` only.**
+  tree clean at start; at exit clean or the two `.claude/remember/` paths
+  only.**
 - **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
   add: "N fixes waiting — run `/refactor` between features." The ledger is a
   local artifact; in the usual case it is gitignored, so writing it moves

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -265,15 +265,45 @@ assumed pass.
 it. `/release` reads this file; a SHA that lives only in a chat message is
 gone after a compaction or a handover, and the only remaining source is the
 orchestrator — the one party this command already refuses to take a review's
-word from. Exactly these five lines:
+word from. **Write it at the end of every run, unconditionally** — not after
+someone decides what to do about it. The information exists now, and the file
+earns its keep only by surviving a compaction, an abandoned session, or a
+handover to someone who never saw the report.
 
 ```
 sha: <full HEAD sha>
 branch: <branch>
 target: <resolved range or path>
+level: <low | medium | high | max>
 verdict: <ready | blocked>
 date: <YYYY-MM-DD>
+coverage: stage1 <ran|NOT RUN>, stage2 <ran|NOT RUN>, stage3 <ran|NOT RUN>
+blockers:
+- <file:line> · <one-sentence claim, no scenario, no suggested fix>
 ```
+
+`blockers: none` when the verdict is ready. One line per blocker and nothing
+more: the reasoning belongs in the report, and the non-blocking findings
+belong in the ledger. This exists so a session that never saw the report can
+learn *what* is blocked, not just *that* something is — otherwise the next
+run rediscovers it by re-reviewing the branch, which is the
+non-convergence this command exists to stop.
+
+`coverage` is recorded because a `ready` from a run whose security stage did
+not execute is not the same fact as one where it did, and the reader of this
+file cannot tell them apart otherwise.
+
+**There is no override field, and no `verdict: overridden`.** A SHA is
+checkable by anyone; consent is not, so a consent line in a file is forgeable
+by whatever writes the file — and a persisted override is reusable, silently
+covering the next release as well as this one. Releasing over a blocked
+review is a live decision made at `/release`'s hand-back, in conversation.
+
+**Nothing clears this file.** It is overwritten whole on the next run, and the
+`sha:` line is what expires it: fix something, commit, and the recorded hash
+no longer matches HEAD, so the gate reports *stale* and asks for a
+re-review rather than *blocked*. A blocked verdict can only persist while HEAD
+does not move — which means nothing was fixed, which is the correct outcome.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -118,7 +118,10 @@ judging.
 not a fact to accept. Branches are commonly AI-authored now — including the
 fixes to the fixes — so a review that trusts the message is reviewing prose.
 Run the test suite and the typecheck/build yourself and cite the command and
-its exit code.
+its exit code. Read that code off the bare command (`cmd > /tmp/out 2>&1;
+e=$?`), never off a pipeline — `$?` after a pipe is the last element's
+status, so piping into `tail` reports `0` for a suite that failed. `/ship`
+carries the reproduction.
 
 - **Bugs needing a fix.** Logic errors, off-by-one, null/undefined paths,
   races, wrong defaults, broken edge cases.

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -10,6 +10,13 @@ audit** — followed by an adversarial verify pass. It **never edits code**: it
 reports findings and hands them back. Fixing is a separate, separately
 authorized action.
 
+Only **Critical** and **High** findings block the merge. Everything else is
+appended to the **fix ledger** (`.claude/remember/fix-ledger.md`) — a
+committed, cumulative list that `/refactor` (no arguments) works through
+between features. The report is blockers plus the ledger count, so a review
+converges instead of surfacing fresh nits every run. This command never runs
+`/refactor` itself — it nudges, the way `/stash` nudges `/remember`.
+
 Run this **before** `/release`. `/release` will refuse to run without a review
 at the current HEAD SHA.
 
@@ -33,9 +40,11 @@ at the current HEAD SHA.
   executed X" from a sub-worker is hearsay, and replacing hearsay with evidence
   is the entire point of this command. A review that delegates its work is a
   review of a report. (Same rule `/security` carries inside stage 2.)
-- **No edits.** You have no authorization to change code, even for a finding
-  you are certain about. Report it. Re-run `git status --porcelain` before you
-  report and confirm it is still empty — if it is not, say what changed. That
+- **No edits — one exception.** You have no authorization to change code,
+  even for a finding you are certain about. Report it. The **only** file you
+  may write is `.claude/remember/fix-ledger.md` (append bullets; never rewrite
+  or delete). Re-run `git status --porcelain` before you report: it must be
+  empty or list exactly that one path — anything else, say what changed. That
   turns "it never edits" from a claim into a checked fact.
 
 ## Target — check the tree first, then interpret `$ARGUMENTS`
@@ -69,6 +78,13 @@ With a clean tree, interpret `$ARGUMENTS` in this order:
 Record the **HEAD SHA** you reviewed, and **report the target you resolved**
 (the literal range or path) in your output, so the orchestrator can see what
 was actually read rather than assuming.
+
+**Re-review after fixes: pass the range `<previously-reviewed-sha>..HEAD`.**
+Stage 1 reads only the fix commits; stage 3 re-verifies the prior report's
+blockers (fixed / unfixed / dismissed — with reason); the rest of the branch is
+**not** re-judged. A full re-read of an already-reviewed branch produces fresh
+findings every time and never converges. The range form still ends at HEAD,
+so `/release`'s precondition is satisfied.
 
 ## Effort level
 `low | medium | high | max` — default **medium** if not given. The level
@@ -164,21 +180,50 @@ verdict first, then repeat it at the end.
 
 Then the findings, ordered most severe first.
 
-### 🚨 Critical (blocks merge)
-### ⚠️ Warnings (should fix)
-### 💡 Suggestions (nice to have)
+### 🚨 Critical / High (blocks merge)
+A **reproduced** failure only: a failing test, a broken build, a security
+exposure, or a bug with a written failure scenario you confirmed in stage 3.
+A finding about a spec's or doc's own prose, structure, or style is **never**
+a blocker. A finding already dismissed with evidence in this project's stash
+or memory cannot come back at a higher severity without **new** evidence —
+check before escalating.
 
-Each finding: **Location** (`file:line`) · **What's wrong** · **Failure
-scenario** (inputs/state → result) · **Why it matters** · **Suggested fix**
-(described, not applied) · **Verdict** (confirmed / uncertain).
+### Ledger (non-blocking — medium / low)
+Not in the report. **Append** each one as a single bullet to
+`.claude/remember/fix-ledger.md` (create the file with the header below if
+missing):
 
-Then a coverage line: stage 1 at level `<level>`, stage 2 full — each `ran ✓/✗`
-with its evidence. A stage you did not actually run is a **✗**, never an
+```
+# Fix ledger
+> Non-blocking review findings. One bullet per item. Delete the bullet when
+> fixed, or when its anchor no longer exists. Written by /branch-review;
+> consumed by /refactor (ledger mode).
+
+- `path/file.js` · "verbatim snippet from the line" · what's wrong · failure
+  scenario · YYYY-MM-DD @ <short sha>
+```
+
+The **snippet is the anchor**: 20–60 verbatim characters from the line,
+unique enough for `git grep -F` to find it after lines shift. No line
+numbers, no TODO comments in code — the ledger is the single writer. Before
+appending, `git grep -F` the snippet in the ledger itself; if it is already
+there, skip it. Do not touch existing bullets.
+
+Each blocking finding: **Location** (`file:line`) · **What's wrong** ·
+**Failure scenario** (inputs/state → result) · **Why it matters** ·
+**Suggested fix** (described, not applied) · **Verdict** (confirmed /
+uncertain).
+
+Then a coverage line: stage 1 at level `<level>`, stage 2 full, stage 3 —
+each `ran ✓/✗` with its evidence. A stage you did not actually run is a **✗**, never an
 assumed pass.
 
 End with:
 - **Reviewed at HEAD `<sha>` on `<branch>`, target `<resolved range or path>`,
-  tree clean at start and at exit.**
+  tree clean at start; at exit clean or `fix-ledger.md` only.**
+- **Fix ledger: N open, M added this run** (N = bullet count). When N > 0,
+  add: "N fixes waiting — run `/refactor` between features." The orchestrator
+  commits the ledger; `/release` accepts a ledger-only commit after the review.
 - One-line verdict: **Ready to merge? Yes / No / Not until these are fixed.**
 - **Escalate to the orchestrator** with the findings. It decides what gets
   fixed and by whom. Say plainly what you could not verify.

--- a/packages/opencode/command/refactor.md
+++ b/packages/opencode/command/refactor.md
@@ -57,7 +57,9 @@ Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 verification, HITL gates) still applies; this section only says what to
 refactor and how to close each item.
 
-1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+1. **Tree must be clean and not on `main`.** The orchestrator runs this check
+   before spawning the worker, so a dirty tree costs no worker; the worker
+   then re-runs it as its own first act. `git status --porcelain` non-empty
    → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
 2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
 3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F

--- a/packages/opencode/command/refactor.md
+++ b/packages/opencode/command/refactor.md
@@ -7,6 +7,50 @@ allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(
 ---
 Refactor $ARGUMENTS.
 
+## Guardrails
+- **Spawn a worker and explicitly select your tool's mid tier.** State the
+  tier on the spawn — do not omit it and rely on a default. An omitted tier
+  inherits the *parent's* tier, which is not the same thing as the balanced
+  one. Pick the judgment-capable tier that is cheaper and faster than your top
+  reasoning tier. **Not the cheapest/fastest tier**: on judgment work it
+  measurably degrades (misclassification rates several times higher). Choose by
+  tier, not by a vendor model name copied from this file — names drift, and
+  this command ships to several tools. Fall back to running inline if your tool
+  has no subagent mechanism.
+- **Escalate, never assume.** Anything you cannot decide, cannot verify, or
+  that this spec does not cover → **stop and report it to the orchestrator**
+  (the main session). Never improvise, never widen scope, never fix a side
+  issue you noticed along the way.
+- **The worker does the work itself — no delegation.** The fixer must **not**
+  spawn subagents of its own. Every edit it reports, and every test run it
+  cites, has to be one it made or ran with its own tool calls: a relayed "I
+  fixed it and the suite is green" from a sub-worker is hearsay, and this
+  command's whole output is the claim that a change landed and the tests still
+  pass. A fix that delegates its work is a report about a report.
+- **The HITL gates below belong to the orchestrator, not the worker.** A
+  subagent cannot hold a conversation with the user, so it cannot run a gate
+  that ends in *stop and ask*. When one trips — a failing test, a crossed
+  public API boundary, a change bigger than the bullet asked for — the worker
+  **stops there and hands the situation back**, with the options and its
+  reasoning but no choice made. The orchestrator asks. A worker that picks
+  revert / patch / update-test on the user's behalf has answered a question it
+  was never allowed to ask.
+- **Edit only what a surviving bullet names.** Ledger mode's scope is the
+  bullets that survive revalidation, one change per bullet — not the
+  neighbouring code, not the formatting, not a second finding noticed on the
+  way past. Anything else goes back to the orchestrator to become a new
+  bullet.
+- **Prove the blast radius with two checks, because neither sees what the
+  other does.** `git status --porcelain` at exit must list only files a
+  surviving bullet named — that is this command's scope guarantee, and unlike
+  `/branch-review` it is not expected to be empty. It cannot police the
+  memory directory: `.claude/` is normally gitignored, so porcelain stays
+  empty whether you deleted a fixed bullet, wrote nothing, or overwrote
+  `MEMORY.md`. So also take `md5sum .claude/remember/*` before you start and
+  again before you report, and show the comparison: only `fix-ledger.md` may
+  differ. `last-review.md` in particular is `/branch-review`'s to write —
+  a fixer that touches it forges the gate that judges its own work.
+
 ## Ledger mode — `$ARGUMENTS` empty
 Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
 `/branch-review` has accumulated. Everything below (goals, constraints,

--- a/packages/opencode/command/refactor.md
+++ b/packages/opencode/command/refactor.md
@@ -1,11 +1,33 @@
 ---
 name: refactor
 description: Refactor [code]
-usage: /refactor <code-section>
-argument-hint: [file-or-function]
-allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *)
+usage: /refactor <code-section> | /refactor (no args = fix-ledger mode)
+argument-hint: [file-or-function, or empty for the fix ledger]
+allowed-tools: Read, Edit, Grep, Glob, Bash(npm test *), Bash(npx jest *), Bash(npx vitest *), Bash(pnpm test *), Bash(yarn test *), Bash(pytest *), Bash(python *), Bash(go test *), Bash(cargo test *), Bash(make test *), Bash(git diff *), Bash(git grep *), Bash(git status *), Bash(git rev-parse *), Bash(git switch *)
 ---
 Refactor $ARGUMENTS.
+
+## Ledger mode — `$ARGUMENTS` empty
+Work through `.claude/remember/fix-ledger.md`, the non-blocking findings
+`/branch-review` has accumulated. Everything below (goals, constraints,
+verification, HITL gates) still applies; this section only says what to
+refactor and how to close each item.
+
+1. **Tree must be clean and not on `main`.** `git status --porcelain` non-empty
+   → stop, say what is uncommitted. On `main` → `git switch -c chore/fix-ledger`.
+2. **Ledger missing or has zero bullets** → say so and stop. Nothing to do.
+3. **Revalidate every bullet first, fix nothing yet.** For each: `git grep -F
+   "<snippet>" -- <path>`. **No hit → delete the bullet** and list it as
+   "cleaned by other work". Hit → re-read the surrounding code; if the finding
+   no longer holds, delete the bullet with a one-line reason. What survives is
+   the work list.
+4. **Fix the survivors, one bullet per change**, under the constraints below.
+   Delete each bullet as its fix lands. A fix that turns out to need a
+   behaviour change is not a refactor — leave the bullet, note it in the report.
+5. Run the tests as described below. Then report: **fixed / dropped / left**
+   with the reason per left item, and the remaining bullet count.
+6. Say plainly: **commit, then run `/branch-review`** on this branch — ledger
+   mode is a fixer, not a review, and its diff gets the ordinary gate.
 
 ## Goals
 - Reduce complexity

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -75,6 +75,9 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`coverage:` naming any stage `NOT RUN`** → **stop**. A `ready` from a run
+  that skipped the security stage is not the same fact as one that did not,
+  and this line is the only place the difference is visible to you.
 - **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
   Read that line as mechanically as the `sha:` one. A matching SHA proves a
   review ran here; it says nothing about what the review concluded, and

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -80,9 +80,14 @@ that predates this file's introduction has no record, so it does not count.
 
 This phase runs **before** `/release` writes anything, so the docs-and-bump
 commit it makes later cannot invalidate the review it just checked. That
-commit is also where a doc-only ledger item is cheapest to close: correcting
-a stale line during the docs sweep costs nothing, where fixing it on its own
-means a commit, a stale review, and a re-review for one word.
+If Phase 2's docs sweep happens to correct a line that a fix-ledger bullet
+also names, that is ordinary sweep work — the doc changed with the feature,
+so it was already yours to update. **Do not delete the bullet.** `/refactor`
+is the only deleter, and its revalidation will drop that bullet on its next
+run when it finds the finding no longer holds. Deleting it here would make
+`/release` a second writer on state that has exactly one owner, and the whole
+value of the ledger's one-append-one-delete split is that it stays readable
+as a log.
 
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -67,12 +67,11 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically, and only in repos that track the
-  ledger** (it is normally gitignored, in which case it never reaches this
-  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
-  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
-  file is the review's own output, not a change to the code it reviewed. Any
-  other path in that list → stale.
+  **No exceptions — including the fix ledger.** It is normally gitignored, so
+  appending to it moves nothing and this never comes up. A repo that tracks
+  `.claude/` instead will see a ledger commit land after the review and make
+  it stale. That is the rule working, not a case to carve out: re-review, or
+  leave the ledger uncommitted until after the release.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -75,6 +75,12 @@ that predates this file's introduction has no record, so it does not count.
   `.claude/` instead will see a ledger commit land after the review and make
   it stale. That is the rule working, not a case to carve out: re-review, or
   leave the ledger uncommitted until after the release.
+- **`verdict: blocked` in the record** → **stop**, even when the SHA matches.
+  Read that line as mechanically as the `sha:` one. A matching SHA proves a
+  review ran here; it says nothing about what the review concluded, and
+  leaving the conclusion to the orchestrator's recollection restores exactly
+  the unverified claim this file replaced. Only `verdict: ready` with a
+  matching SHA is a pass.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -67,6 +67,10 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
+  **One carve-out, checked mechanically:** if `git diff --name-only
+  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
+  nothing else, the review stands — the ledger is the review's own output,
+  committed after it by design. Any other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -160,15 +160,27 @@ orchestrator can run them on the user's named go:
 > Ready when you are:
 > 1. `git push -u origin <branch>`
 > 2. `gh pr create` into `main`
-> 3. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
+> 3. `gh pr checks <pr> --watch` — **merge only on green.** Every gate before
+>    this one ran on the same machine; CI is the only differently-configured
+>    instrument in the chain, and this is the first time it sees the branch.
+>    A test that passes locally because of a path, a fixture, or a tool that
+>    exists only on your box fails here and nowhere earlier. Read the exit
+>    code off the bare command. Red → stop, fix, re-review, and start again.
+> 4. `gh pr merge --admin --squash --delete-branch` (main is PR-protected;
 >    owner-authorized admin merge on a solo repo). **Keep `--squash`** — `gh`
 >    requires an explicit merge-method flag (`--squash` / `--merge` /
 >    `--rebase`); drop it and the command will not squash-merge.
-> 4. `git tag vX.Y.Z` on `main` and push the tag
-> 5. Publish **if this project has a publish path** (e.g.
+> 5. `git tag vX.Y.Z` on `main` and push the tag
+> 6. Publish **if this project has a publish path** (e.g.
 >    `gh workflow run publish.yml`) — manual by design
-> 6. Verify it is actually live (`npm view <pkg> version`, and the published
+> 7. Verify it is actually live (`npm view <pkg> version`, and the published
 >    tarball's contents), not the working tree
+
+**Every exit code in this sequence is read off the bare command, including
+the ones you type yourself.** `/ship`'s rule is not just for the worker: a
+pipeline reports its last element's status, so `gh run watch --exit-status |
+tail -2; echo $?` prints `0` for a failed run. That has already turned a red
+CI into a green reading in a real release.
 
 Final line: **Cut ✅ (vX.Y.Z — ready to push)** or **Blocked 🛑** with the
 specific reason.

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -78,6 +78,12 @@ that predates this file's introduction has no record, so it does not count.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 
+This phase runs **before** `/release` writes anything, so the docs-and-bump
+commit it makes later cannot invalidate the review it just checked. That
+commit is also where a doc-only ledger item is cheapest to close: correcting
+a stale line during the docs sweep costs nothing, where fixing it on its own
+means a commit, a stale review, and a re-review for one word.
+
 Report the comparison you actually ran: recorded `<sha>` vs HEAD `<sha>`,
 match yes/no.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -67,10 +67,12 @@ not evidence: obtain the review's own recorded SHA and match the two strings.
 - **Stale** — recorded SHA ≠ `git rev-parse HEAD`, i.e. commits landed after
   the review (including fix commits) → **stop** and ask for a re-review. This
   is what makes "all findings fixed" checkable instead of promised.
-  **One carve-out, checked mechanically:** if `git diff --name-only
-  <recorded-sha>..HEAD` prints exactly `.claude/remember/fix-ledger.md` and
-  nothing else, the review stands — the ledger is the review's own output,
-  committed after it by design. Any other path in that list → stale.
+  **One carve-out, checked mechanically, and only in repos that track the
+  ledger** (it is normally gitignored, in which case it never reaches this
+  diff at all): if `git diff --name-only <recorded-sha>..HEAD` prints exactly
+  `.claude/remember/fix-ledger.md` and nothing else, the review stands — that
+  file is the review's own output, not a change to the code it reviewed. Any
+  other path in that list → stale.
 - **Reviewed at this SHA with findings outstanding** → **stop**. Findings are
   resolved before a release is cut.
 

--- a/packages/opencode/command/release.md
+++ b/packages/opencode/command/release.md
@@ -56,11 +56,14 @@ separate command that must have run first.
 A review must have run on this branch **at the current HEAD SHA**.
 
 **Compare the SHAs yourself; do not settle for an answer.** Run `git rev-parse
-HEAD` and compare it against the SHA the review recorded — `/branch-review`
-ends with `Reviewed at HEAD <sha>`. Asking the orchestrator "did a review run?"
-puts the question to the one party with an incentive to say yes, so its word is
-not evidence: obtain the review's own recorded SHA and match the two strings.
-**No recorded SHA to compare = no review**, never a pass.
+HEAD` and compare it against the `sha:` line in
+`.claude/remember/last-review.md`, which `/branch-review` writes. Asking the
+orchestrator "did a review run?" puts the question to the one party with an
+incentive to say yes, so its word is not evidence — and neither is a SHA
+quoted from a chat message, which is the same claim in another costume and is
+gone after a compaction or a handover. Read the file; match the two strings.
+**No such file, or no `sha:` line in it = no review**, never a pass. A review
+that predates this file's introduction has no record, so it does not count.
 
 - **No review**, or no recorded SHA obtainable → **stop**: "No review at
   `<sha>`. Run `/branch-review medium` (or `/code-review medium`) first."

--- a/packages/opencode/command/remember.md
+++ b/packages/opencode/command/remember.md
@@ -380,7 +380,8 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      <!-- AGENT_RULES:END -->
      ```
    - Each marker pair is independent: if AGENTS.md lacks a given pair, append it at the
-     end; if no AGENTS.md exists, create one containing whichever section(s) apply.
+     end; if a given pair already exists, replace its content in place; if no AGENTS.md
+     exists, create one containing whichever section(s) apply.
    - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
      block above is what to write when creating it, not a template to re-impose every run.
      Users trim this section deliberately (a pointer-only variant is common), and rewriting

--- a/packages/opencode/command/remember.md
+++ b/packages/opencode/command/remember.md
@@ -133,6 +133,14 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      Re-processing a stash whose episode is already filed must not create a near-duplicate
      pair. Every older episode is **folded, then deleted**: its lesson becomes a fact (handed
      to the rewrite above); the narrative is removed. No archive — git has the history.
+     **Specify the operation once.** The keep-10 rule is the rule; the set to remove is
+     *derived* from it, never supplied alongside it as a second list. Given both, an agent
+     applies both and removes their union — observed in the field: a run told to keep 10 and
+     handed a 5-entry delete list removed 7, and the 2 extras were never folded, so one
+     lesson left memory with nothing carrying it. **No episode is removed whose lesson has
+     not been folded into a fact first**, and the two sets must match: state the count
+     before, the count after, and name each episode removed. Removed-but-not-folded is a
+     defect to report, not a tidy-up.
    - **Antigens section**: only update from friction output (step 4)
    - Write merged result to `.opencode/remember/MEMORY.md` in the format under step 5.
 
@@ -276,7 +284,11 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
        recurrence; a single occurrence has none to track yet. Friction re-scans every
        session log every run, so a later run matches it back to 2+ sessions and seeds it
        then — this does not change matching against an EXISTING entry, which is recurrence
-       regardless of the matching cluster's own session count.
+       regardless of the matching cluster's own session count. **A match is not an
+       increment.** Whether it counts as a new conversation is decided in 4c by
+       `friction.cjs count`, which is a no-op when that session hash is already stored — so
+       several matches against one entry routinely produce zero increments, and that is
+       correct, not a miscount.
      - For `new:<theme>` groups with no ledger match: distinct conversations = distinct
        cluster indices in the group (within one classify batch, no two cluster indices
        share a session hash). `sessions < 2` → writes nothing. `sessions >= 2` → new entry,
@@ -367,9 +379,17 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      .opencode/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->
      ```
-   - Each marker pair is independent: if AGENTS.md already has a given pair, replace the
-     section between them; if not, append it at the end; if no AGENTS.md exists, create one
-     containing whichever section(s) apply
+   - Each marker pair is independent: if AGENTS.md lacks a given pair, append it at the
+     end; if no AGENTS.md exists, create one containing whichever section(s) apply.
+   - **An existing AGENT_RULES pair is left alone — bootstrap once, never overwrite.** The
+     block above is what to write when creating it, not a template to re-impose every run.
+     Users trim this section deliberately (a pointer-only variant is common), and rewriting
+     it silently re-adds text they removed, on every single run, forever. Observed in the
+     field: a run restored the inline rules into a AGENTS.md whose owner had cut them, and
+     the edit had to be reverted by hand. This matches how `AGENT_RULES.md` itself is
+     handled — bootstrapped once, never overwritten after.
+   - If an existing pair is present but its **path pointer** is missing or wrong, that is
+     load-bearing: **report it and stop**, do not silently rewrite the section around it.
 
    ```markdown
    # Project Memory

--- a/packages/opencode/command/remember.md
+++ b/packages/opencode/command/remember.md
@@ -346,11 +346,23 @@ Reads all raw material (`.opencode/stash/*.md` + `.opencode/remember/friction/an
      inline duplication is needed
    - If `.opencode/remember/AGENT_RULES.md` exists (bootstrapped in step 1), compose a second,
      independent section between `<!-- AGENT_RULES:START -->` and `<!-- AGENT_RULES:END -->`
-     markers. Unlike MEMORY.md above, this is a **plain path pointer, never `@`-referenced**
-     — an `@`-reference hot-loads the whole file into every session, and this is a standards
-     guide to consult when designing/building something new, not hot context:
+     markers. Unlike MEMORY.md above, the file itself is **never `@`-referenced** — an
+     `@`-reference hot-loads all ~300 lines into every session, and it is a standards guide
+     to consult when designing/building something new, not hot context. The section carries
+     a path pointer plus exactly two inline rules: the ones that change what you TYPE, which
+     you cannot look up because you do not know you need them. Everything else stays behind
+     the pointer. Write the section verbatim, rules first:
      ```
      <!-- AGENT_RULES:START -->
+     **One writer per piece of state.** One function assigns each field; everything else
+     calls it. Grep who writes it before you write it — and if a write can land from a
+     callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+     **Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you
+     pass: if it's inside or affects the code you're already changing and the fix changes
+     no behavior, fix it and say so — otherwise report it and say what it costs to leave
+     it. A problem you don't fix goes in the report, never in a comment.
+
      Standards guide (read when designing/building something new, not hot context):
      .opencode/remember/AGENT_RULES.md
      <!-- AGENT_RULES:END -->

--- a/packages/opencode/command/remember/AGENT_RULES.md
+++ b/packages/opencode/command/remember/AGENT_RULES.md
@@ -105,11 +105,14 @@ Before adding any external dependency, all of these must be true:
 
 - **Open-source only.** Always use open-source solutions. No vendor lock-in
 - **Lightweight over complex.** If two solutions solve the same problem, use the one with fewer moving parts, fewer dependencies, and less configuration
-- **Every line must have a purpose.** No speculative code, no "might need this later", no abstractions for one use case
+- **Every line earns its place.** If you can't say what breaks when it's deleted, delete it. No speculative code, no "might need this later", no abstractions for one use case. One function, one concern, one owner — small blocks beat spaghetti
 - **Simple > clever.** Readable code that a junior can follow beats elegant code that requires a PhD to debug
+- **One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it. Ownership says *where*, not *when* — if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh
+- **Split the decision from the machinery.** A branch whose outcome matters, tangled with a framework, IO, or UI object, moves into a pure function; the framework class applies the result. Extract to pin a branch, not to raise coverage — a one-line delegation in its own file buys a test that cannot fail
+- **Claims in comments must be checkable.** "The only place that writes X" is a claim — run the grep first, and expect the next reader to re-run it. A name search proves an edge exists, never that one doesn't
 - **Containerize only when necessary.** Start with a virtualenv or bare metal. Docker adds value for deployment parity and isolation — not for running a script
 - **Responsive web UI is mandatory in dev projects.** Any web UI must be usable on mobile by default — fluid layouts, viewport meta tag, breakpoints for narrow screens, no horizontal scroll. Test in DevTools device emulation before declaring a UI task done. POCs are exempt (validate the idea first), but the moment a POC graduates to a real project this becomes a hard requirement
-- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created — leave pre-existing dead code alone unless asked. Every changed line should trace directly to the request
+- **Surgical changes only.** Touch what the task requires; nothing else. Don't "improve" adjacent code, comments, or formatting. Match existing style even if you'd do it differently. Only clean up orphans your own change created. Dead code, nits, bugs you pass on the way: if it's inside or affects the code you're already changing, and the fix changes no behavior, fix it and say so. Otherwise report it — say what it costs to leave it. "It would be nicer" is not a cost. Every changed line traces to the request or to a fix you named
 
 ### Red Flags — Stop and Flag These
 - Over-engineering simple problems
@@ -120,6 +123,8 @@ Before adding any external dependency, all of these must be true:
 - POC-ing only the easy part while hand-waving the risky mechanism, or claiming a cost ("cheap"/"fast"/"constant") you never measured
 - Authoring a fixture/corpus that *guarantees* the result (a test that can't return the negative), or trusting a degenerate-looking number without auditing the harness for confounds — use real uncrafted data; the test must be able to fail
 - Fitting a POC to pass (narrowed input, moved threshold, shrunk scope) instead of reporting the failure; starting module N+1 while module N is unproven
+
+A problem you see and don't fix goes in the report, never in a comment. Comments are where findings go to be forgotten.
 
 ---
 
@@ -291,7 +296,11 @@ Copy this to any project's AGENTS.md. These are mandatory rules, not suggestions
 
 **Lightweight over complex.** Fewer moving parts, fewer deps, less config. Express over NestJS, Flask over Django, unless the project genuinely needs the framework. Simple > clever. Readable > elegant.
 
-**Open-source only.** No vendor lock-in. Every line of code must have a purpose — no speculative code, no premature abstractions.
+**Open-source only.** No vendor lock-in. Every line of code earns its place — if you can't say what breaks when it's deleted, delete it. No speculative code, no premature abstractions.
+
+**One writer per piece of state.** One function assigns each field; everything else calls it. Grep who writes it before you write it — and if a write can land from a callback, thread, or lifecycle, the reader must tell stale from fresh.
+
+**Surgical changes only.** Touch what the task requires. Dead code, nits, bugs you pass: if it's inside or affects the code you're already changing and the fix changes no behavior, fix it and say so — otherwise report it and say what it costs to leave it. A problem you don't fix goes in the report, never in a comment.
 
 **Responsive web UI is mandatory.** Any web UI must work on mobile by default — fluid layouts, viewport meta, breakpoints, no horizontal scroll. Verify in DevTools device emulation before claiming a UI task is done. POCs exempt; real projects are not.
 

--- a/packages/opencode/command/ship.md
+++ b/packages/opencode/command/ship.md
@@ -20,6 +20,22 @@ its exit code**. A check you did not run is a **fail**, never a pass. **N/A
 requires a stated reason** ("no build script in `package.json`") — N/A must
 never stand in for "didn't get to it."
 
+**Capture the exit code of the command itself, never of a pipeline.** Run the
+bare command, then read `$?` on the next line:
+
+```
+node "$f" > /tmp/out 2>&1; e=$?
+```
+
+`$?` after a pipe is the *last element's* status, so the common shape
+`out=$(cmd 2>&1 | tail -1); echo "exit=$?"` reports `tail`'s success — `0` —
+for a suite that exited `2`. Reproduced: a check printing "exit 2:
+prerequisites missing" was recorded as a pass by exactly that loop. Nor does
+`${PIPESTATUS[0]}` rescue it inside a command substitution; it is empty by
+the time you read it. This is the rule the whole gate rests on, and the
+piped form is the natural way to write a multi-suite loop, so it fails
+silently and in the unsafe direction.
+
 ## Checklist
 - [ ] **Tests pass** — run the project's real test command (`npm test`,
       `pytest`, `go test ./...`, `cargo test`, `make test`).


### PR DESCRIPTION
Cut as **v2.23.0**. Reviewed at `df4e799` (`/branch-review medium`, verdict `ready`, all three stages ran, 0 blockers); `/ship` green, 977/977.

## What's in it

**`/refactor` gains a Guardrails block** ported from `/branch-review`: mid-tier worker spawn with the tier stated explicitly, escalate-never-assume, no sub-delegation, edit-only-what-a-surviving-bullet-names, and a two-check blast-radius proof. Two parts were rewritten rather than copied — "no edits" inverts into a scope rule, and the three HITL gates move to the orchestrator, because a subagent cannot hold a conversation and a spawn without that rule silently converts three stop-and-ask gates into three unilateral decisions.

**`/branch-review` durable review record** — `level`, `coverage`, `blockers`, `verdict` on `.claude/remember/last-review.md`, read mechanically by `/release` Phase 0.5. Ledger dedupe moved to plain `grep -F` (a gitignored ledger is invisible to `git grep`, so the old dedupe silently passed every time). Re-review reads the prior SHA and blockers from the record rather than from the orchestrator.

**State ownership** added as a stage-1 finding category, plus four Build Rules in `AGENT_RULES.md`.

**Fix-ledger closure** — the ledger's first real repair run: three bullets revalidated and fixed across all four kits.

**`/remember` known limitations** documented — matching semantics and evidence are the same channel, and a run cannot tell its own work invalidated a standing fact.

## Validated by running, not reading

This branch's review, re-review, refactor and release were all dogfooded on the branch itself. That exercised the new record fields, the `grep -F` dedupe, the `md5sum` exit check, prior-SHA-from-record, `sha != HEAD` re-review scoping, the ledger liveness sweep, and `/refactor`'s repair loop — which repaired something for the first time.

Known gap, recorded rather than hidden: `remember-README.md` §6 says the evidence/matching coupling has no fix that is not a trade. A route was found after it was written (`preceding` is computed but never stored on a ledger entry). Correcting §6 is the next branch's first task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)