### PR TITLE
release: v2.24.1 — record the file-referent shelving decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [2.24.1] - 2026-09-03
 
 ### Changed
 - **The file-referent ledger half is SHELVED — no demonstrated problem.** The v2.24.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "AI development toolkit with 11 specialized agents and 18 commands including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Version bump only. **No code change.**

The one allowlisted delta against v2.24.0 is the CHANGELOG entry documenting that the file-referent ledger half is SHELVED — why the "gated on exact-label agreement" premise was wrong, and the checkable un-shelve trigger replacing it. The docs and POC backing that decision (merged in #46) live in `docs/product/` and `poc/`, both outside `package.json`'s `files` allowlist, so they do not ship in the tarball.

## Diff

- `package.json` — `2.24.0` → `2.24.1`
- `CHANGELOG.md` — `## [Unreleased]` → `## [2.24.1] - 2026-09-03`

Exactly one changed line each.

## Verification

- `npm test` — exit 0, **999/999**.
- `npm pack --dry-run` — exit 0, **210 files, 862.9 kB packed / 3.3 MB unpacked**. No `docs/`, no `poc/`, no `node_modules`, no `.env`, no `test-report.json`/`TEST_REPORT.md`. `CHANGELOG.md` included. The tarball delta vs 2.24.0 is the changelog text and nothing else.
- `installer/cli.js:19` derives `PACKAGE_VERSION` from `package.json` at runtime — not hardcoded, nothing else to bump. No lockfile exists, so `publish.yml` takes its `npm install --no-audit --no-fund` branch; it asserts the registry end-state rather than trusting npm's exit code.
- `/branch-review low` at `1e4e36e` — **ready**, zero findings.

## Review scope, stated plainly

Stage 2 was scoped to a secrets scan of the packed file list and the 2-line diff; the full `security.md` checklist was **not** re-run — it ran on the branch merged in #46. Stage 3 is recorded `NOT RUN` and is vacuous here (findings are its input; there were none), but that record would stop a future `/release` at Phase 0.5.

After merge: tag `v2.24.1` on `main`, then dispatch `publish.yml` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QodDFbdJpH1v2AAaV2LLZU