### PR TITLE
release: v3.5.0 — capabilities are skills; Amp install fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [4.0.0] - 2026-09-05
+## [3.5.0] - 2026-09-05
 
 ### Breaking
 - **Every capability is a skill on Claude Code and Amp.** Claude Code merged
@@ -66,8 +66,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CLAUDE.md` points at it.
 
 ### Fixed
-- **Test-count floors realigned.** The Multi-Tool Installation floor was
-  lowered 36 -> 33 to match the capability cut (Claude has no `commands/`
+
+- **Amp installs delivered no capabilities.** This release moved ampcode from
+  `commands/` to `skills/`, but `packages/ampcode/variants.json` was left
+  declaring only `agents`. The installer selects content by that field, so
+  `selectVariantContent()` returned an empty skills list and an Amp install
+  carried 10 agents and zero of the 13 capabilities. Added `"skills": "*"`.
+  Caught by `prepublishOnly`'s package validator, which is why the first cut never
+  reached the registry.
+- `scripts/validate-package.js` still mapped ampcode's capability directory to
+  `commands`; it is `skills`.
+- **Test-count floors realigned.** The Multi-Tool Installation floor moved
+  36 -> 41 (33 to match the capability cut, then +8 for the new
+  variant-selection assertions; Claude has no `commands/`
   directory now, so the suite counts three categories per scenario, not four),
   and four floors that had drifted below their suites' actual counts were
   raised to match: docs-builder 497 -> 538, friction 254 -> 323, sync-rules
@@ -98,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous check flagged in-repo links too; mirrored to all four kits.
 
 ### Changed
+
+- `npm test` now runs `scripts/validate-package.js` as its last step, so the
+  publish-time validator runs locally instead of only inside `publish.yml`.
+  The first cut's gate went green on a package publish then rejected.
+- New `testVariantSelectionDelivers` in the multi-tool suite asserts what the
+  installer actually *selects* per tool, not what the package tree contains.
+  The existing scenarios copy the whole tree and read `variants.json` only to
+  check the variant key exists, so they could not see a missing content field.
 - Six commands and skills that had no `allowed-tools` at all — `remember`,
   `stash`, `brainstorming`, `live-canvas`, `root-cause`, `skill-creator` — now
   declare a `Read, Grep, Glob` floor, so those calls stop prompting. Subagents

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "4.0.0",
+  "version": "3.5.0",
   "description": "AI development toolkit with 10 specialized agents and 13 capabilities including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {
@@ -8,7 +8,7 @@
     "liteag": "./cli.js"
   },
   "scripts": {
-    "test": "node scripts/mirror.cjs check && node tests/run-all-tests.js",
+    "test": "node scripts/mirror.cjs check && node tests/run-all-tests.js && node ./scripts/validate-package.js",
     "mirror": "node scripts/mirror.cjs",
     "test-installer": "node tests/installer/integration.test.js",
     "install-interactive": "node installer/cli.js",

--- a/packages/ampcode/variants.json
+++ b/packages/ampcode/variants.json
@@ -1,7 +1,8 @@
 {
   "pro": {
     "name": "Pro",
-    "description": "Complete installation with all agents and commands",
-    "agents": "*"
+    "description": "Complete installation with all agents and skills",
+    "agents": "*",
+    "skills": "*"
   }
 }

--- a/scripts/validate-package.js
+++ b/scripts/validate-package.js
@@ -180,7 +180,7 @@ function validateToolPackages() {
     },
     ampcode: {
       agents: 'agents',
-      skills: 'commands'
+      skills: 'skills'
     },
     droid: {
       agents: 'droids',

--- a/tests/installer/multi-tool-testing.test.js
+++ b/tests/installer/multi-tool-testing.test.js
@@ -253,7 +253,42 @@ function testMultiToolInstallation(testConfig) {
 /**
  * Run all multi-tool tests
  */
-function runAllTests() {
+/**
+ * The variant-selection path, which the copy-the-whole-tree scenarios above
+ * cannot see. installToolPackage() reads variants.json only to check the
+ * variant key exists and then copies every file, so a tool whose variants.json
+ * is missing a content field still "delivers" the right file count on disk
+ * while a real install delivers nothing. v4.0.0 was cut with exactly that bug:
+ * ampcode moved commands/ -> skills/ but its variants.json kept only `agents`,
+ * so selectVariantContent() returned zero skills and an Amp install would have
+ * carried no capabilities at all. This asserts what the installer selects.
+ */
+async function testVariantSelectionDelivers() {
+  console.log('\nTesting: Variant selection delivers expected content');
+  console.log('─'.repeat(60));
+
+  const PackageManager = require('../../installer/package-manager.js');
+  const pm = new PackageManager();
+
+  for (const [tool, expected] of Object.entries(EXPECTED)) {
+    const selected = await pm.getPackageContents(tool, VARIANT);
+    for (const [category, count] of Object.entries(expected)) {
+      if (category === 'plugins') continue; // plugins are not variant-selected
+      // Mirror COUNT_BY: commands are .md files, skills are directories. The
+      // selection also carries each capability's bundled asset directory
+      // (remember/, docs-builder/, ...), which is correct to install but is
+      // not itself a capability, so it must not be counted as one.
+      const names = new Set(selected[category].map((p) => path.basename(p)));
+      const actual = COUNT_BY[category] === 'md'
+        ? [...names].filter((n) => n.endsWith('.md')).length
+        : [...names].filter((n) => !n.endsWith('.md')).length;
+      logTest(`Variant selection: ${tool} ${category} count`, actual === count,
+        actual === count ? `${actual}` : `expected ${count}, got ${actual}`);
+    }
+  }
+}
+
+async function runAllTests() {
   console.log('\x1b[1m\x1b[36m');
   console.log('╔════════════════════════════════════════════════════════════╗');
   console.log('║       Multi-Tool Installation Testing Suite               ║');
@@ -271,6 +306,8 @@ function runAllTests() {
   for (const config of testConfigs) {
     testMultiToolInstallation(config);
   }
+
+  await testVariantSelectionDelivers();
 
   // Print summary
   console.log('\n\x1b[1m\x1b[36m');
@@ -301,7 +338,10 @@ function runAllTests() {
 
 // Run tests if executed directly
 if (require.main === module) {
-  runAllTests();
+  runAllTests().catch((err) => {
+    console.error(`\x1b[31mTest run crashed: ${err.stack || err}\x1b[0m`);
+    process.exit(1);
+  });
 }
 
 module.exports = {

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -34,10 +34,12 @@ const testSuites = [
     name: 'Multi-Tool Installation',
     file: 'installer/multi-tool-testing.test.js',
     description: 'Tests simultaneous installation of multiple tools',
-    // 33 since Claude Code's capabilities became skills: the suite counts one
-    // assertion per content category per scenario, and claude no longer has a
-    // commands/ directory to count (3 scenarios x 1 category = the -3).
-    expectedTests: 33
+    // 41 = 33 from the copy-the-tree scenarios (one assertion per content
+    // category per scenario; claude has no commands/ directory to count since
+    // its capabilities became skills) + 8 from testVariantSelectionDelivers,
+    // which asserts what the installer actually SELECTS rather than what the
+    // package tree contains.
+    expectedTests: 41
   },
   {
     name: 'Error Scenario Testing',


### PR DESCRIPTION
Finishes the v3.5.0 release. Blocks publish until merged.

## The bug

Moving ampcode from `commands/` to `skills/` left `packages/ampcode/variants.json` declaring only `agents`. The installer selects content by that field, so `selectVariantContent()` returned an empty skills list — **an Amp install shipped 10 agents and none of the 13 capabilities.**

Caught by `prepublishOnly`'s package validator, which is why nothing was ever published at the earlier cut.

## Fixes

- `packages/ampcode/variants.json` — added `"skills": "*"` (0 → 13 skills selected)
- `scripts/validate-package.js` — ampcode's capability dir mapped to `commands`; it is `skills`
- `package.json` — `npm test` now runs `scripts/validate-package.js`, so the publish-time gate runs locally instead of only in `publish.yml`
- `tests/installer/multi-tool-testing.test.js` — new `testVariantSelectionDelivers` asserts what the installer *selects* per tool; floor 33 → 41

## Why 1068 tests missed it

The existing scenarios copy the whole package tree and read `variants.json` only to confirm the variant key exists. A missing content field is invisible to them.

## Verification

- `npm test` — 1076/1076 + validator, exit 0
- Failing-first: reverting only `variants.json` → `ampcode skills count: expected 13, got 0`, suite exits 1
- `/branch-review` at `371ea01`: verdict ready, all three stages ran, reproduced the bug independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QodDFbdJpH1v2AAaV2LLZU