### PR TITLE
release: v3.6.0 — frontmatter freeze, review-record guard, installer test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ test-installation-*/
 !/tests/stub-check/stub-check.test.js
 !/tests/installer/
 !/tests/installer/closing-note.test.js
+!/tests/mirror/
+!/tests/mirror/mirror.test.js
 
 # Release artifacts
 liteagents-*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.6.0] - 2026-09-05
+
+### Added
+- **`scripts/frontmatter.json` is frozen and date-stamped.** `mirror.cjs
+  shapes` now refuses to overwrite a recorded shape with a weaker one (a
+  required key demoted to optional, gone entirely, or a `Bash()` style
+  relaxed to `null`) — it reports `WEAKENING` instead of writing. `--force`
+  re-records it deliberately and updates the frozen date.
+- **`mirror.cjs check` detects orphaned kit files** — a file under a mirrored
+  tool directory with no corresponding source under `packages/claude`, left
+  behind when a capability moves or is removed.
+- **`/branch-review`'s review-record guard.** A recorded `last-review.md` is
+  now validated before being trusted: its `sha:` must resolve to a real
+  commit and be an ancestor of `HEAD`, and its `branch:` must match the
+  current branch. A record that fails either check — hand-edited, corrupted,
+  or left over from a merged, renamed, or rebased branch — is treated as no
+  record at all, falling through to a full review. Previously only the
+  `sha:` line was compared, so a stale record resolved to a commit range
+  that never existed.
+
+### Fixed
+- **`supported_variants` removed from all four `tools/*/manifest-template.json`.**
+  It advertised `["lite","standard","pro"]` in every installed `manifest.json`
+  when only one install exists, and nothing read the field.
+- **`tests/installer/package-manager.test.js` was never registered** in
+  `tests/run-all-tests.js`, so it had never run. Standalone it failed 22 of
+  44 tests against the removed three-variant installer, and wrote 11 fixtures
+  into `packages/` inside the repo. Rewritten against the single-variant
+  reality, every fixture now in an isolated temp directory, and registered.
+
+### Changed
+- Installer test coverage: 1103 → 1153 tests. `getAvailableContent`'s
+  deduplication — a capability shipping both `<name>.md` and a same-named
+  `<name>/` asset directory must be listed once — now has a regression suite
+  of its own.
+
 ## [3.5.0] - 2026-09-05
 
 ### Breaking

--- a/docs/log.md
+++ b/docs/log.md
@@ -12,3 +12,4 @@
 ## [2026-09-04] index-flat | 8 row(s) (7 product, 0 logs, 1 archive)
 ## [2026-09-04] index-flat | 9 row(s) (8 product, 0 logs, 1 archive)
 ## [2026-09-04] index-flat | 10 row(s) (9 product, 0 logs, 1 archive)
+## [2026-09-05] index-flat | 10 row(s) (9 product, 0 logs, 1 archive)

--- a/docs/product/INSTALLER_GUIDE.md
+++ b/docs/product/INSTALLER_GUIDE.md
@@ -578,6 +578,15 @@ It is verified against `scripts/frontmatter.json` instead, which is generated
 from the real files by `node scripts/mirror.cjs shapes`. Regenerate it only
 when a shape genuinely changes — never to silence a failing check.
 
+`scripts/frontmatter.json` is frozen and date-stamped once recorded: `shapes`
+refuses to overwrite a frozen shape that comes out weaker (a required key
+demoted to optional, gone entirely, or a `Bash()` style relaxed to `null`),
+and reports `WEAKENING` instead of writing. Pass `--force` to deliberately
+re-record it anyway; that updates the frozen date. `check` also flags orphaned
+kit files — anything under a mirrored tool directory with no corresponding
+source under `packages/claude`, left behind when a capability moves or is
+removed.
+
 ### Escape hatches
 
 Use the smallest one that works. Every entry is coverage you give up.

--- a/docs/product/branch-review-README.md
+++ b/docs/product/branch-review-README.md
@@ -352,6 +352,12 @@ where the previously-reviewed commit comes from, and its `blockers:` list is wha
 owes an answer on. Taking either from whoever invoked the command would reintroduce the
 recollection problem the record exists to end.
 
+Before branching on it, the record is validated: its `sha:` must resolve to a real
+commit and be an ancestor of `HEAD`, and its `branch:` must match the current branch. A
+record that fails either check — a hand-edited or corrupted `sha:`, or one left over from
+a merged, renamed, or rebased branch — is treated as if there were no record at all,
+falling through to a full review rather than resolving a range that never existed.
+
 - **`sha:` ≠ HEAD** → re-review over `<that sha>..HEAD`.
 - **`sha:` = HEAD** → nothing changed; say so and stop rather than re-run an identical
   tree. A recorded `blocked` verdict means its blockers are unfixed by definition.

--- a/docs/product/docs-builder-README.md
+++ b/docs/product/docs-builder-README.md
@@ -145,7 +145,7 @@ REPO=<repo> OUT=lint.json node docs-builder.cjs lint $(git ls-files 'docs/*.md')
 
 **The script lives next to the command, not in your repo.** Every `node
 docs-builder/docs-builder.cjs …` in the spec is relative to the command's own directory
-(`~/.claude/commands/` once installed); the target repo is whatever `REPO=` names, defaulting
+(`~/.claude/skills/` once installed); the target repo is whatever `REPO=` names, defaulting
 to the cwd. The spec now says so up front — before it did, a run on an external repo searched
 the target tree for the script, found nothing, and refused (see History).
 

--- a/installer/package-manager.js
+++ b/installer/package-manager.js
@@ -349,7 +349,9 @@ class PackageManager {
         }
       }
 
-      return { items: result, dirName: path.basename(dir) };
+      // A command with both a <name>.md file and a same-named <name>/
+      // subdirectory (bundled assets) would otherwise appear twice here.
+      return { items: [...new Set(result)], dirName: path.basename(dir) };
     };
 
     // Check for both plural and singular directory names

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liteagents",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "AI development toolkit with 10 specialized agents and 13 capabilities including live-canvas UI design with click-to-annotate feedback. Simple one-question installer for Claude, Opencode, Ampcode, and Droid.",
   "main": "index.js",
   "bin": {

--- a/packages/ampcode/skills/branch-review/SKILL.md
+++ b/packages/ampcode/skills/branch-review/SKILL.md
@@ -100,6 +100,16 @@ was actually read rather than assuming.
 you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
+- **First, check the record belongs to this branch.** There is one record file
+  per repo, not one per branch. If its `branch:` line differs from the current
+  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
+  the record describes a different or rewritten history — treat it exactly as
+  **No file** below and review the whole branch. Skipping this resolves
+  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
+  subset of this branch but a range that never existed. Check both: the branch
+  name catches a switch, the ancestry check catches a rebase or squash under
+  the same name. Otherwise:
+
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
   re-verifies each recorded blocker as fixed, unfixed, or dismissed with a

--- a/packages/ampcode/skills/branch-review/SKILL.md
+++ b/packages/ampcode/skills/branch-review/SKILL.md
@@ -101,14 +101,18 @@ you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
 - **First, check the record belongs to this branch.** There is one record file
-  per repo, not one per branch. If its `branch:` line differs from the current
-  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
-  the record describes a different or rewritten history — treat it exactly as
-  **No file** below and review the whole branch. Skipping this resolves
-  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
-  subset of this branch but a range that never existed. Check both: the branch
-  name catches a switch, the ancestry check catches a rebase or squash under
-  the same name. Otherwise:
+  per repo, not one per branch. Validate `<that sha>` first with
+  `git rev-parse --verify <that sha>` — a value that fails this (e.g. a
+  corrupted or hand-edited record, or one starting with `-`, which git would
+  otherwise parse as an option) is a malformed record; treat it exactly as
+  **No file** below. If it validates, and its `branch:` line differs from the
+  current branch, or `git merge-base --is-ancestor <that sha> HEAD` exits
+  non-zero, the record describes a different or rewritten history — treat it
+  exactly as **No file** below and review the whole branch. Skipping this
+  resolves `<that sha>..HEAD` against a merged, renamed, or rebased sha, which
+  is not a subset of this branch but a range that never existed. Check both:
+  the branch name catches a switch, the ancestry check catches a rebase or
+  squash under the same name. Otherwise:
 
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3

--- a/packages/claude/skills/branch-review/SKILL.md
+++ b/packages/claude/skills/branch-review/SKILL.md
@@ -100,6 +100,16 @@ was actually read rather than assuming.
 you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
+- **First, check the record belongs to this branch.** There is one record file
+  per repo, not one per branch. If its `branch:` line differs from the current
+  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
+  the record describes a different or rewritten history — treat it exactly as
+  **No file** below and review the whole branch. Skipping this resolves
+  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
+  subset of this branch but a range that never existed. Check both: the branch
+  name catches a switch, the ancestry check catches a rebase or squash under
+  the same name. Otherwise:
+
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
   re-verifies each recorded blocker as fixed, unfixed, or dismissed with a

--- a/packages/claude/skills/branch-review/SKILL.md
+++ b/packages/claude/skills/branch-review/SKILL.md
@@ -101,14 +101,18 @@ you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
 - **First, check the record belongs to this branch.** There is one record file
-  per repo, not one per branch. If its `branch:` line differs from the current
-  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
-  the record describes a different or rewritten history — treat it exactly as
-  **No file** below and review the whole branch. Skipping this resolves
-  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
-  subset of this branch but a range that never existed. Check both: the branch
-  name catches a switch, the ancestry check catches a rebase or squash under
-  the same name. Otherwise:
+  per repo, not one per branch. Validate `<that sha>` first with
+  `git rev-parse --verify <that sha>` — a value that fails this (e.g. a
+  corrupted or hand-edited record, or one starting with `-`, which git would
+  otherwise parse as an option) is a malformed record; treat it exactly as
+  **No file** below. If it validates, and its `branch:` line differs from the
+  current branch, or `git merge-base --is-ancestor <that sha> HEAD` exits
+  non-zero, the record describes a different or rewritten history — treat it
+  exactly as **No file** below and review the whole branch. Skipping this
+  resolves `<that sha>..HEAD` against a merged, renamed, or rebased sha, which
+  is not a subset of this branch but a range that never existed. Check both:
+  the branch name catches a switch, the ancestry check catches a rebase or
+  squash under the same name. Otherwise:
 
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -97,6 +97,16 @@ was actually read rather than assuming.
 you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
+- **First, check the record belongs to this branch.** There is one record file
+  per repo, not one per branch. If its `branch:` line differs from the current
+  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
+  the record describes a different or rewritten history — treat it exactly as
+  **No file** below and review the whole branch. Skipping this resolves
+  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
+  subset of this branch but a range that never existed. Check both: the branch
+  name catches a switch, the ancestry check catches a rebase or squash under
+  the same name. Otherwise:
+
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
   re-verifies each recorded blocker as fixed, unfixed, or dismissed with a

--- a/packages/droid/commands/branch-review.md
+++ b/packages/droid/commands/branch-review.md
@@ -98,14 +98,18 @@ you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
 - **First, check the record belongs to this branch.** There is one record file
-  per repo, not one per branch. If its `branch:` line differs from the current
-  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
-  the record describes a different or rewritten history — treat it exactly as
-  **No file** below and review the whole branch. Skipping this resolves
-  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
-  subset of this branch but a range that never existed. Check both: the branch
-  name catches a switch, the ancestry check catches a rebase or squash under
-  the same name. Otherwise:
+  per repo, not one per branch. Validate `<that sha>` first with
+  `git rev-parse --verify <that sha>` — a value that fails this (e.g. a
+  corrupted or hand-edited record, or one starting with `-`, which git would
+  otherwise parse as an option) is a malformed record; treat it exactly as
+  **No file** below. If it validates, and its `branch:` line differs from the
+  current branch, or `git merge-base --is-ancestor <that sha> HEAD` exits
+  non-zero, the record describes a different or rewritten history — treat it
+  exactly as **No file** below and review the whole branch. Skipping this
+  resolves `<that sha>..HEAD` against a merged, renamed, or rebased sha, which
+  is not a subset of this branch but a range that never existed. Check both:
+  the branch name catches a switch, the ancestry check catches a rebase or
+  squash under the same name. Otherwise:
 
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -97,14 +97,18 @@ you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
 - **First, check the record belongs to this branch.** There is one record file
-  per repo, not one per branch. If its `branch:` line differs from the current
-  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
-  the record describes a different or rewritten history — treat it exactly as
-  **No file** below and review the whole branch. Skipping this resolves
-  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
-  subset of this branch but a range that never existed. Check both: the branch
-  name catches a switch, the ancestry check catches a rebase or squash under
-  the same name. Otherwise:
+  per repo, not one per branch. Validate `<that sha>` first with
+  `git rev-parse --verify <that sha>` — a value that fails this (e.g. a
+  corrupted or hand-edited record, or one starting with `-`, which git would
+  otherwise parse as an option) is a malformed record; treat it exactly as
+  **No file** below. If it validates, and its `branch:` line differs from the
+  current branch, or `git merge-base --is-ancestor <that sha> HEAD` exits
+  non-zero, the record describes a different or rewritten history — treat it
+  exactly as **No file** below and review the whole branch. Skipping this
+  resolves `<that sha>..HEAD` against a merged, renamed, or rebased sha, which
+  is not a subset of this branch but a range that never existed. Check both:
+  the branch name catches a switch, the ancestry check catches a rebase or
+  squash under the same name. Otherwise:
 
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3

--- a/packages/opencode/command/branch-review.md
+++ b/packages/opencode/command/branch-review.md
@@ -96,6 +96,16 @@ was actually read rather than assuming.
 you owe an answer on — take both from the file, never from the orchestrator's
 recollection, for the same reason `/release` does. Then:
 
+- **First, check the record belongs to this branch.** There is one record file
+  per repo, not one per branch. If its `branch:` line differs from the current
+  branch, or `git merge-base --is-ancestor <that sha> HEAD` exits non-zero,
+  the record describes a different or rewritten history — treat it exactly as
+  **No file** below and review the whole branch. Skipping this resolves
+  `<that sha>..HEAD` against a merged, renamed, or rebased sha, which is not a
+  subset of this branch but a range that never existed. Check both: the branch
+  name catches a switch, the ancestry check catches a rebase or squash under
+  the same name. Otherwise:
+
 - **`sha:` ≠ HEAD** → this is a re-review. Target the range
   `<that sha>..HEAD`. Stage 1 reads only the commits since, and stage 3
   re-verifies each recorded blocker as fixed, unfixed, or dismissed with a

--- a/scripts/frontmatter.json
+++ b/scripts/frontmatter.json
@@ -1,4 +1,5 @@
 {
+  "frozen": "2026-09-05",
   "subagent": {
     "claude": {
       "required": [

--- a/scripts/mirror.cjs
+++ b/scripts/mirror.cjs
@@ -194,8 +194,8 @@ function bashStyle(text) {
   return /Bash\([^)]*:\*\)/.test(line) ? 'colon' : 'space';
 }
 
-/** Derive the shape file from what the files actually say today. */
-function shapes() {
+/** What the files actually say today — the candidate shape. */
+function computeShapes() {
   const out = {};
   for (const [kind, dirs] of Object.entries(DIRS)) {
     out[kind] = {};
@@ -215,8 +215,68 @@ function shapes() {
       };
     }
   }
-  fs.writeFileSync(SHAPE_FILE, `${JSON.stringify(out, null, 2)}\n`);
-  console.log(`wrote ${path.relative(ROOT, SHAPE_FILE)}`);
+  return out;
+}
+
+/**
+ * Compare a frozen shape against a freshly computed one. Anything that makes
+ * the check WEAKER (a required key demoted to optional or dropped entirely,
+ * or a bashStyle relaxed to null) is flagged as WEAKENING; everything else
+ * (a key added, an optional key dropped) is reported as a plain change.
+ */
+function diffShapes(old, neu) {
+  const lines = [];
+  for (const kind of new Set([...Object.keys(old), ...Object.keys(neu)])) {
+    const oldKits = old[kind] || {};
+    const newKits = neu[kind] || {};
+    for (const kit of new Set([...Object.keys(oldKits), ...Object.keys(newKits)])) {
+      const o = oldKits[kit] || { required: [], optional: [], bashStyle: null };
+      const n = newKits[kit] || { required: [], optional: [], bashStyle: null };
+      for (const k of o.required) {
+        if (n.required.includes(k)) continue;
+        lines.push(n.optional.includes(k)
+          ? `WEAKENING ${kind}/${kit}: '${k}' demoted from required to optional`
+          : `WEAKENING ${kind}/${kit}: required key '${k}' disappeared entirely`);
+      }
+      for (const k of n.required) if (!o.required.includes(k)) lines.push(`  ${kind}/${kit}: '${k}' added to required`);
+      for (const k of o.optional) if (!n.optional.includes(k) && !n.required.includes(k)) lines.push(`  ${kind}/${kit}: optional key '${k}' disappeared`);
+      for (const k of n.optional) if (!o.optional.includes(k) && !o.required.includes(k)) lines.push(`  ${kind}/${kit}: '${k}' added to optional`);
+      if (o.bashStyle !== n.bashStyle) {
+        lines.push(`${n.bashStyle === null && o.bashStyle ? 'WEAKENING ' : '  '}${kind}/${kit}: bashStyle changed from ${o.bashStyle} to ${n.bashStyle}`);
+      }
+    }
+  }
+  return lines;
+}
+
+/**
+ * scripts/frontmatter.json freezes the shape recorded the day it was last
+ * deliberately (re-)recorded — it is the truth `check` judges files against,
+ * not a rolling derivation from today's files. Without freezing, dropping a
+ * key from every file of a kit and re-running `shapes` makes the key silently
+ * stop being required: a circular, useless check. The top-level `frozen` date
+ * lives alongside the per-kind keys (subagent/command/skill); checkFrontmatter
+ * only ever reads shape[kind] for kind in DIRS, so it already ignores `frozen`
+ * without needing a special case.
+ */
+function shapes() {
+  const force = process.argv.includes('--force');
+  const computed = computeShapes();
+  if (fs.existsSync(SHAPE_FILE) && !force) {
+    const { frozen, ...existing } = JSON.parse(fs.readFileSync(SHAPE_FILE, 'utf8'));
+    const diffs = diffShapes(existing, computed);
+    if (diffs.length) {
+      console.error(`${path.relative(ROOT, SHAPE_FILE)} is frozen as of ${frozen || 'unknown'} — refusing to overwrite it.`);
+      console.error('Re-run with --force to deliberately re-record it (this updates the frozen date).\n');
+      console.error(diffs.join('\n'));
+      process.exit(1);
+    }
+    console.log(`${path.relative(ROOT, SHAPE_FILE)} already matches the frozen shape (frozen ${frozen}); nothing to do.`);
+    return;
+  }
+  const frozen = new Date().toISOString().slice(0, 10);
+  fs.writeFileSync(SHAPE_FILE, `${JSON.stringify({ frozen, ...computed }, null, 2)}\n`);
+  console.log(`wrote ${path.relative(ROOT, SHAPE_FILE)} (frozen ${frozen})`);
 }
 
 // A path that belongs to a different tool. Each kit's own dirs are stripped
@@ -345,6 +405,32 @@ function checkFrontmatter() {
   return problems;
 }
 
+/**
+ * A file present under a kit's cmd/agent dir with no matching packages/claude
+ * source is a stale orphan left behind when a capability moves or is removed.
+ * The expected set is built the same way the writer builds a destination path
+ * (sources() mapped through relFor), which naturally covers bundled asset
+ * files too since sources() already walks each skill directory recursively.
+ * An EXEMPT entry's path is still included here — EXEMPT only excuses the
+ * writer from judging that file's BODY, the file itself is still expected to
+ * exist, so it must never be reported as an orphan.
+ */
+function checkOrphans() {
+  const problems = [];
+  const src = sources();
+  for (const kit of Object.values(KITS)) {
+    const expected = new Set(src.map((e) => J(kit.dir, e.kind === 'cmd' ? kit.cmd : kit.agent, relFor(e, kit))));
+    for (const sub of [kit.cmd, kit.agent]) {
+      const dir = J(kit.dir, sub);
+      if (!fs.existsSync(dir)) continue;
+      for (const f of walk(dir)) {
+        if (!expected.has(f)) problems.push(`ORPHAN  ${path.relative(ROOT, f)}: no matching packages/claude source`);
+      }
+    }
+  }
+  return problems;
+}
+
 function main() {
   const mode = process.argv[2] || 'check';
   if (mode === 'shapes') return shapes();
@@ -353,7 +439,7 @@ function main() {
     process.exit(2);
   }
   const problems = mode === 'check'
-    ? [...checkFrontmatter(), ...checkPaths(), ...checkInstallPaths()] : [];
+    ? [...checkFrontmatter(), ...checkPaths(), ...checkInstallPaths(), ...checkOrphans()] : [];
   let written = 0;
   let checked = 0;
 

--- a/scripts/mirror.cjs
+++ b/scripts/mirror.cjs
@@ -26,7 +26,8 @@ const path = require('path');
 const ROOT = path.resolve(__dirname, '..');
 const J = (...p) => path.join(ROOT, ...p);
 
-// Ordered longest-match-first: the first pair that matches a substring wins.
+// Ordered longest-match-first: substitute() applies every pair in order via
+// reduce, so an earlier pair can affect what a later pair matches.
 const KITS = {
   droid: {
     dir: 'packages/droid', cmd: 'commands', agent: 'droids',
@@ -58,7 +59,6 @@ const KITS = {
       ['~/.claude/skills/', '~/.config/opencode/command/'],
       ['~/.claude/commands/', '~/.config/opencode/command/'],
       ['~/.claude/agents/', '~/.config/opencode/agent/'],
-      ['~/.claude/skills/', '~/.config/opencode/command/'],
       ['~/.claude/', '~/.config/opencode/'],
       ['.claude/', '.opencode/'],
       ["'.claude'", "'.opencode'"],

--- a/tests/installer/package-manager-dedup.test.js
+++ b/tests/installer/package-manager-dedup.test.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * installer/package-manager.js getAvailableContent dedup tests
+ *
+ * Why this file exists: a capability may ship both `<name>.md` and a
+ * same-named `<name>/` directory of bundled assets — `remember.md` plus
+ * `remember/friction.cjs` is the live case. getItemsInDir walks a directory
+ * and pushes the file (minus `.md`) and the directory under the same name,
+ * so without a dedup the capability is listed twice, the installer copies it
+ * twice and the progress count is inflated. `[...new Set(result)]` closes it.
+ *
+ * Why not tests/installer/package-manager.test.js: that file is deliberately
+ * not wired into tests/run-all-tests.js (see the comment above `testSuites`)
+ * and currently fails 22 of its own tests against a removed 3-variant
+ * installer. A regression test parked there would never run, which is worse
+ * than none — it reads as protection while guarding nothing.
+ *
+ * Conventions follow tests/installer/closing-note.test.js: self-contained,
+ * no network/TTY, isolated tmpdirs, and a negative control so the suite can
+ * prove it is able to FAIL rather than passing vacuously.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PackageManager = require(path.join(__dirname, '..', '..', 'installer', 'package-manager.js'));
+
+const colors = { reset: '\x1b[0m', green: '\x1b[32m', red: '\x1b[31m',
+  yellow: '\x1b[33m', cyan: '\x1b[36m', bright: '\x1b[1m' };
+
+let passed = 0, failed = 0;
+const failures = [];
+
+function check(name, cond, detail) {
+  if (cond) { passed++; console.log(`  ${colors.green}PASS${colors.reset} ${name}`); }
+  else {
+    failed++; failures.push({ name, detail });
+    console.log(`  ${colors.red}FAIL${colors.reset} ${name}`);
+    if (detail) console.log(`       ${colors.yellow}${detail}${colors.reset}`);
+  }
+}
+
+// KEEP_TMP=1 leaves the fixture behind for debugging; otherwise every run
+// cleans up, since leftover mkdtemp dirs exhaust inodes rather than bytes.
+async function withFixture(fn) {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pm-dedup-'));
+  try {
+    return await fn(dir);
+  } finally {
+    if (!process.env.KEEP_TMP) {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * A capability that ships both forms: `<name>.md` beside `<name>/`.
+ */
+async function writePairedCapability(parent, name) {
+  await fs.promises.mkdir(path.join(parent, name), { recursive: true });
+  await fs.promises.writeFile(path.join(parent, `${name}.md`), `# ${name}\n`);
+  await fs.promises.writeFile(path.join(parent, name, 'asset.cjs'), '// bundled asset\n');
+}
+
+async function main() {
+  const pm = new PackageManager();
+
+  console.log(`${colors.bright}${colors.cyan}getAvailableContent dedup${colors.reset}\n`);
+
+  // 1. The live shape: commands/remember.md beside commands/remember/.
+  await withFixture(async (dir) => {
+    const commands = path.join(dir, 'commands');
+    await writePairedCapability(commands, 'remember');
+    const content = await pm.getAvailableContent(dir);
+    check('paired command is listed once, not twice',
+      content.commands.length === 1 && content.commands[0] === 'remember',
+      `expected ['remember'], got ${JSON.stringify(content.commands)}`);
+  });
+
+  // 2. Negative control. This is the pre-fix mapping, applied by hand to the
+  // same fixture: readdir yields both entries and both collapse to the same
+  // name once `.md` is stripped. If this stops holding, the fixture no longer
+  // reproduces the bug and check 1 above would pass vacuously.
+  await withFixture(async (dir) => {
+    const commands = path.join(dir, 'commands');
+    await writePairedCapability(commands, 'remember');
+    const raw = await fs.promises.readdir(commands);
+    const preFix = raw.map((e) => e.replace('.md', ''));
+    check('negative control: fixture really does yield a duplicate pre-dedup',
+      preFix.length === 2 && preFix[0] === 'remember' && preFix[1] === 'remember',
+      `pre-fix mapping produced ${JSON.stringify(preFix)}; the fixture no longer reproduces the bug`);
+  });
+
+  // 3. opencode installs to the singular `command/`, which getAvailableContent
+  // resolves separately — the dedup has to hold on that path too.
+  await withFixture(async (dir) => {
+    const command = path.join(dir, 'command');
+    await writePairedCapability(command, 'docs-builder');
+    const content = await pm.getAvailableContent(dir);
+    check('dedup holds for the singular command/ directory',
+      content.commandsDir === 'command' && content.commands.length === 1,
+      `commandsDir=${content.commandsDir}, commands=${JSON.stringify(content.commands)}`);
+  });
+
+  // 4. Agents are read with the same helper and the same `.md` stripping.
+  await withFixture(async (dir) => {
+    const agents = path.join(dir, 'agents');
+    await writePairedCapability(agents, 'orchestrator');
+    const content = await pm.getAvailableContent(dir);
+    check('paired agent is listed once, not twice',
+      content.agents.length === 1 && content.agents[0] === 'orchestrator',
+      `expected ['orchestrator'], got ${JSON.stringify(content.agents)}`);
+  });
+
+  // 5. The dedup must not collapse genuinely distinct capabilities.
+  await withFixture(async (dir) => {
+    const commands = path.join(dir, 'commands');
+    await writePairedCapability(commands, 'remember');
+    await fs.promises.writeFile(path.join(commands, 'ship.md'), '# ship\n');
+    const content = await pm.getAvailableContent(dir);
+    const sorted = [...content.commands].sort();
+    check('distinct capabilities are both kept',
+      sorted.length === 2 && sorted[0] === 'remember' && sorted[1] === 'ship',
+      `expected ['remember','ship'], got ${JSON.stringify(sorted)}`);
+  });
+
+  // 6. Skills are directories only; a stray .md beside them is ignored, so a
+  // paired name there must still resolve to one entry.
+  await withFixture(async (dir) => {
+    const skills = path.join(dir, 'skills');
+    await writePairedCapability(skills, 'security');
+    const content = await pm.getAvailableContent(dir);
+    check('paired skill is listed once (files ignored in skills/)',
+      content.skills.length === 1 && content.skills[0] === 'security',
+      `expected ['security'], got ${JSON.stringify(content.skills)}`);
+  });
+
+  // 7. The tmpdir is cleaned up unless KEEP_TMP is set.
+  {
+    let leaked = null;
+    await withFixture(async (dir) => { leaked = dir; });
+    check('fixture tmpdir is removed on exit',
+      process.env.KEEP_TMP ? fs.existsSync(leaked) : !fs.existsSync(leaked),
+      `${leaked} still exists after the fixture closed`);
+  }
+}
+
+main().then(() => {
+  // Summary format is a contract with tests/run-all-tests.js, which parses
+  // /Total tests:\s+(\d+)/, /Passed:\s+(\d+)/ and /Failed:\s+(\d+)/. Emit
+  // anything else and the runner reads 0 tests and fails the count floor.
+  console.log(`\n${colors.bright}${'='.repeat(60)}${colors.reset}`);
+  console.log(`Total tests: ${passed + failed}`);
+  console.log(`${colors.green}Passed: ${passed}${colors.reset}`);
+  console.log(`${colors.red}Failed: ${failed}${colors.reset}`);
+  if (failed) {
+    console.log(`\n${colors.red}Failures:${colors.reset}`);
+    for (const f of failures) console.log(`  - ${f.name}${f.detail ? `: ${f.detail}` : ''}`);
+  }
+  process.exit(failed ? 1 : 0);
+}).catch((err) => {
+  console.error(`${colors.red}Suite crashed:${colors.reset} ${err && err.stack || err}`);
+  console.log(`\nTotal tests: ${passed + failed}`);
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed + 1}`);
+  process.exit(1);
+});

--- a/tests/installer/package-manager.test.js
+++ b/tests/installer/package-manager.test.js
@@ -1,1025 +1,414 @@
+#!/usr/bin/env node
+
 /**
- * Package Manager Tests
+ * installer/package-manager.js behavioural tests
  *
- * Tests for variant configuration loading and parsing
+ * Rewritten from scratch. The previous version of this file (1025 lines, 44
+ * tests) asserted a three-variant ('lite', 'standard', 'pro') installer that
+ * no longer exists — every packages/<tool>/variants.json now ships exactly
+ * one variant, 'pro'. Standalone it scored 22 pass / 22 fail, and it was never wired into
+ * tests/run-all-tests.js, so none of that ever ran in CI. It also wrote
+ * fixtures directly under packages/ (the real tool-package tree the
+ * installer enumerates), which a crash mid-test could strand there.
+ *
+ * This version:
+ *  - asserts only the single-variant ('pro') reality; an old test whose
+ *    intent still applies (e.g. "throws for an unknown variant") is kept
+ *    with a variant name that is actually unknown ('lite'/'standard'
+ *    instead of pretending they should exist);
+ *  - never writes inside the repo — every fixture is an fs.mkdtemp() dir
+ *    under os.tmpdir(), cleaned up in `finally` (KEEP_TMP=1 to inspect);
+ *  - where a method needs a fixture, it does so by pointing a fresh
+ *    PackageManager instance's own `packagesDir` field at the tmpdir
+ *    (a plain instance property, not a source-code change) rather than
+ *    writing into the real packages/ tree;
+ *  - exercises real packages/* content directly wherever that is enough
+ *    (no fixture needed, no risk of drifting from reality);
+ *  - does NOT test getAvailableContent's dedup behaviour — that is fully
+ *    covered by tests/installer/package-manager-dedup.test.js (7 tests).
+ *
+ * Conventions follow tests/installer/package-manager-dedup.test.js and
+ * tests/installer/closing-note.test.js: self-contained, no network/TTY,
+ * isolated tmpdirs, negative controls / real-data checks so each test is
+ * provably able to FAIL rather than passing vacuously.
  */
 
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const PackageManager = require('../../installer/package-manager.js');
 
-// ANSI color codes for better test output
-const colors = {
-  reset: '\x1b[0m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-  blue: '\x1b[34m',
-  cyan: '\x1b[36m',
-  gray: '\x1b[90m'
-};
+const PM_PATH = path.join(__dirname, '..', '..', 'installer', 'package-manager.js');
+const PackageManager = require(PM_PATH);
 
-// Test utilities
-function log(message, color = 'reset') {
-  console.log(`${colors[color]}${message}${colors.reset}`);
-}
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const REAL_PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
 
-function logTest(name, passed, details = '') {
-  const symbol = passed ? '✓' : '✗';
-  const color = passed ? 'green' : 'red';
-  log(`  ${symbol} ${name}`, color);
-  if (details && !passed) {
-    log(`    ${details}`, 'gray');
+const colors = { reset: '\x1b[0m', green: '\x1b[32m', red: '\x1b[31m',
+  yellow: '\x1b[33m', cyan: '\x1b[36m', bright: '\x1b[1m' };
+
+let passed = 0, failed = 0;
+const failures = [];
+
+function check(name, cond, detail) {
+  if (cond) { passed++; console.log(`  ${colors.green}PASS${colors.reset} ${name}`); }
+  else {
+    failed++; failures.push({ name, detail });
+    console.log(`  ${colors.red}FAIL${colors.reset} ${name}`);
+    if (detail) console.log(`       ${colors.yellow}${detail}${colors.reset}`);
   }
 }
 
-// Test counters
-let totalTests = 0;
-let passedTests = 0;
-let failedTests = 0;
-
-// Test runner
-function test(name, fn) {
-  totalTests++;
-  try {
-    fn();
-    passedTests++;
-    logTest(name, true);
-  } catch (error) {
-    failedTests++;
-    logTest(name, false, error.message);
-  }
-}
-
-// Async test runner
-async function testAsync(name, fn) {
-  totalTests++;
+async function checkThrows(name, fn, matcher) {
   try {
     await fn();
-    passedTests++;
-    logTest(name, true);
-  } catch (error) {
-    failedTests++;
-    logTest(name, false, error.message);
+    check(name, false, 'expected a throw, none occurred');
+  } catch (err) {
+    const ok = matcher(err.message);
+    check(name, ok, `unexpected message: ${err.message}`);
   }
 }
 
-// Test suite header
-function describe(name) {
-  log(`\n${name}`, 'cyan');
+// KEEP_TMP=1 leaves the fixture behind for debugging; otherwise every run
+// cleans up, since leftover mkdtemp dirs exhaust inodes rather than bytes.
+async function withFixture(fn) {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pm-'));
+  try {
+    return await fn(dir);
+  } finally {
+    if (!process.env.KEEP_TMP) {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+  }
 }
 
-// Main test execution
-async function runTests() {
-  log('\n=== Package Manager Tests ===', 'blue');
-  log('Testing variant configuration loading and parsing\n', 'gray');
-
+// Builds a fixture "packages" root: <root>/<toolId>/variants.json (+ agents).
+// Returns a PackageManager whose packagesDir is repointed at the fixture
+// root — an instance-property override, not a change to package-manager.js.
+function pmOverPackagesDir(packagesDir) {
   const pm = new PackageManager();
-
-  // Test 2.1: loadVariantConfig() method
-  describe('loadVariantConfig(toolId)');
-
-  await testAsync('should load and parse valid variants.json for Claude', async () => {
-    const config = await pm.loadVariantConfig('claude');
-    assert(config !== null, 'Config should not be null');
-    assert(typeof config === 'object', 'Config should be an object');
-  });
-
-  await testAsync('should cache loaded configurations', async () => {
-    // Load first time
-    const config1 = await pm.loadVariantConfig('claude');
-    // Load second time (should use cache)
-    const config2 = await pm.loadVariantConfig('claude');
-    assert.strictEqual(config1, config2, 'Should return same cached object');
-  });
-
-  await testAsync('should validate all three required variants exist (lite, standard, pro)', async () => {
-    const config = await pm.loadVariantConfig('claude');
-    assert(config.lite, 'lite variant should exist');
-    assert(config.standard, 'standard variant should exist');
-    assert(config.pro, 'pro variant should exist');
-  });
-
-  await testAsync('should validate variant has required fields', async () => {
-    const config = await pm.loadVariantConfig('claude');
-    const liteVariant = config.lite;
-
-    assert(liteVariant.name, 'Variant should have name field');
-    assert(liteVariant.description, 'Variant should have description field');
-    assert(liteVariant.agents !== undefined, 'Variant should have agents field');
-    assert(liteVariant.skills !== undefined, 'Variant should have skills field');
-    assert(liteVariant.resources !== undefined, 'Variant should have resources field');
-    assert(liteVariant.hooks !== undefined, 'Variant should have hooks field');
-  });
-
-  await testAsync('should load variants.json for all tools (claude, opencode, ampcode, droid)', async () => {
-    const tools = ['claude', 'opencode', 'ampcode', 'droid'];
-    for (const tool of tools) {
-      const config = await pm.loadVariantConfig(tool);
-      assert(config !== null, `Config for ${tool} should not be null`);
-      assert(config.lite && config.standard && config.pro, `${tool} should have all variants`);
-    }
-  });
-
-  await testAsync('should throw error for non-existent tool', async () => {
-    try {
-      await pm.loadVariantConfig('nonexistent-tool');
-      throw new Error('Should have thrown error for non-existent tool');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('ENOENT'),
-        'Error should indicate file not found');
-    }
-  });
-
-  await testAsync('should throw error for invalid JSON', async () => {
-    // Create temporary invalid JSON file
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-invalid');
-    const tempFile = path.join(tempDir, 'variants.json');
-
-    try {
-      // Create temp directory and invalid JSON file
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-      fs.writeFileSync(tempFile, '{ invalid json }');
-
-      // Test
-      try {
-        await pm.loadVariantConfig('test-invalid');
-        throw new Error('Should have thrown error for invalid JSON');
-      } catch (error) {
-        assert(error.message.includes('JSON') || error.message.includes('parse'),
-          'Error should indicate JSON parsing failure');
-      }
-    } finally {
-      // Cleanup
-      if (fs.existsSync(tempFile)) {
-        fs.unlinkSync(tempFile);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should throw error if required variants are missing', async () => {
-    // Create temporary file with missing variant
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-incomplete');
-    const tempFile = path.join(tempDir, 'variants.json');
-
-    try {
-      // Create temp directory and incomplete variants.json
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-      fs.writeFileSync(tempFile, JSON.stringify({
-        lite: { name: 'Lite', agents: [], skills: [], resources: [], hooks: [] },
-        standard: { name: 'Standard', agents: [], skills: [], resources: [], hooks: [] }
-        // Missing 'pro' variant
-      }));
-
-      // Test
-      try {
-        await pm.loadVariantConfig('test-incomplete');
-        throw new Error('Should have thrown error for missing variant');
-      } catch (error) {
-        assert(error.message.includes('pro') || error.message.includes('variant'),
-          'Error should indicate missing variant');
-      }
-    } finally {
-      // Cleanup
-      if (fs.existsSync(tempFile)) {
-        fs.unlinkSync(tempFile);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  describe('getVariantMetadata(toolId, variant)');
-
-  await testAsync('should retrieve metadata for a specific variant', async () => {
-    const metadata = await pm.getVariantMetadata('claude', 'lite');
-    assert(metadata !== null, 'Metadata should not be null');
-    assert(metadata.name === 'Lite', 'Name should match');
-    assert(typeof metadata.description === 'string', 'Should have description');
-    assert(typeof metadata.useCase === 'string', 'Should have useCase');
-    assert(typeof metadata.targetUsers === 'string', 'Should have targetUsers');
-  });
-
-  await testAsync('should retrieve metadata for all variants', async () => {
-    const variants = ['lite', 'standard', 'pro'];
-    for (const variant of variants) {
-      const metadata = await pm.getVariantMetadata('claude', variant);
-      assert(metadata !== null, `Metadata for ${variant} should not be null`);
-      assert(metadata.name, `${variant} should have name`);
-    }
-  });
-
-  await testAsync('should throw error for invalid variant name', async () => {
-    try {
-      await pm.getVariantMetadata('claude', 'invalid-variant');
-      throw new Error('Should have thrown error for invalid variant');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('invalid'),
-        'Error should indicate invalid variant');
-    }
-  });
-
-  describe('selectVariantContent(toolId, variant, availableContent)');
-
-  // Helper to get available content from Claude package
-  const getAvailableClaudeContent = async () => {
-    const baseDir = path.join(__dirname, '..', '..', 'packages', 'claude');
-
-    const getFilesInDir = async (dir) => {
-      if (!fs.existsSync(dir)) return [];
-      const items = await fs.promises.readdir(dir);
-      // Filter out directories, return only files
-      const files = [];
-      for (const item of items) {
-        const itemPath = path.join(dir, item);
-        const stat = await fs.promises.stat(itemPath);
-        if (stat.isFile()) {
-          // Return just the filename without extension for agents
-          if (dir.includes('agents')) {
-            files.push(item.replace('.md', ''));
-          } else {
-            files.push(item);
-          }
-        } else if (stat.isDirectory()) {
-          // For skills (which are directories), just include the directory name
-          files.push(item);
-        }
-      }
-      return files;
-    };
-
-    return {
-      agents: await getFilesInDir(path.join(baseDir, 'agents')),
-      skills: await getFilesInDir(path.join(baseDir, 'skills')),
-      resources: await getFilesInDir(path.join(baseDir, 'resources')),
-      hooks: await getFilesInDir(path.join(baseDir, 'hooks'))
-    };
-  };
-
-  await testAsync('should expand wildcard "*" to all available items', async () => {
-    const available = await getAvailableClaudeContent();
-    const selected = await pm.selectVariantContent('claude', 'pro', available);
-
-    // Pro variant uses "*" for all categories
-    assert.strictEqual(selected.agents.length, available.agents.length,
-      `Should select all ${available.agents.length} agents`);
-    assert.strictEqual(selected.skills.length, available.skills.length,
-      `Should select all ${available.skills.length} skills`);
-    assert.strictEqual(selected.resources.length, available.resources.length,
-      `Should select all ${available.resources.length} resources`);
-    assert.strictEqual(selected.hooks.length, available.hooks.length,
-      `Should select all ${available.hooks.length} hooks`);
-  });
-
-  await testAsync('should select specific items when array is provided', async () => {
-    const available = await getAvailableClaudeContent();
-    const selected = await pm.selectVariantContent('claude', 'lite', available);
-
-    // Lite variant has specific agents: ["master", "orchestrator", "scrum-master"]
-    assert.strictEqual(selected.agents.length, 3, 'Should select exactly 3 agents');
-    assert(selected.agents.includes('master'), 'Should include master agent');
-    assert(selected.agents.includes('orchestrator'), 'Should include orchestrator agent');
-    assert(selected.agents.includes('scrum-master'), 'Should include scrum-master agent');
-
-    // Lite variant has empty skills array
-    assert.strictEqual(selected.skills.length, 0, 'Should select no skills');
-  });
-
-  await testAsync('should select standard variant with specific skills', async () => {
-    const available = await getAvailableClaudeContent();
-    const selected = await pm.selectVariantContent('claude', 'standard', available);
-
-    // Standard variant has all agents (wildcard)
-    assert.strictEqual(selected.agents.length, available.agents.length,
-      'Should select all agents');
-
-    // Standard variant has 8 specific skills
-    assert.strictEqual(selected.skills.length, 8, 'Should select exactly 8 skills');
-
-    const expectedSkills = ['pdf', 'docx', 'xlsx', 'pptx', 'canvas-design',
-                           'theme-factory', 'brand-guidelines', 'internal-comms'];
-    for (const skill of expectedSkills) {
-      assert(selected.skills.includes(skill), `Should include ${skill} skill`);
-    }
-  });
-
-  await testAsync('should handle empty array selection []', async () => {
-    const available = await getAvailableClaudeContent();
-    const selected = await pm.selectVariantContent('claude', 'lite', available);
-
-    // Lite has empty skills array
-    assert.strictEqual(selected.skills.length, 0, 'Empty array should result in no selections');
-    assert(Array.isArray(selected.skills), 'Should return empty array, not undefined');
-  });
-
-  await testAsync('should validate that specified items exist in available content', async () => {
-    const available = {
-      agents: ['master', 'orchestrator'],
-      skills: ['pdf', 'docx'],
-      resources: ['config.yaml'],
-      hooks: ['startup.js']
-    };
-
-    // Create temp variants.json with non-existent item
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-validation');
-    const tempFile = path.join(tempDir, 'variants.json');
-
-    try {
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-
-      fs.writeFileSync(tempFile, JSON.stringify({
-        lite: {
-          name: 'Test',
-          description: 'Test',
-          agents: ['master', 'nonexistent-agent'],  // nonexistent-agent doesn't exist
-          skills: [],
-          resources: '*',
-          hooks: '*'
-        },
-        standard: {
-          name: 'Standard',
-          description: 'Standard',
-          agents: '*',
-          skills: '*',
-          resources: '*',
-          hooks: '*'
-        },
-        pro: {
-          name: 'Pro',
-          description: 'Pro',
-          agents: '*',
-          skills: '*',
-          resources: '*',
-          hooks: '*'
-        }
-      }));
-
-      try {
-        await pm.selectVariantContent('test-validation', 'lite', available);
-        throw new Error('Should have thrown error for non-existent item');
-      } catch (error) {
-        assert(error.message.includes('nonexistent-agent') || error.message.includes('not found'),
-          'Error should indicate missing item');
-      }
-    } finally {
-      // Cleanup
-      if (fs.existsSync(tempFile)) {
-        fs.unlinkSync(tempFile);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should return object with all content categories', async () => {
-    const available = await getAvailableClaudeContent();
-    const selected = await pm.selectVariantContent('claude', 'standard', available);
-
-    assert(selected !== null, 'Result should not be null');
-    assert(typeof selected === 'object', 'Result should be an object');
-    assert(Array.isArray(selected.agents), 'Should have agents array');
-    assert(Array.isArray(selected.skills), 'Should have skills array');
-    assert(Array.isArray(selected.resources), 'Should have resources array');
-    assert(Array.isArray(selected.hooks), 'Should have hooks array');
-  });
-
-  await testAsync('should work with all tools (claude, opencode, ampcode, droid)', async () => {
-    const available = await getAvailableClaudeContent();
-    const tools = ['claude', 'opencode', 'ampcode', 'droid'];
-
-    for (const tool of tools) {
-      const selected = await pm.selectVariantContent(tool, 'standard', available);
-      assert(selected !== null, `Should return selection for ${tool}`);
-      assert(Array.isArray(selected.agents), `${tool} should have agents array`);
-      assert(Array.isArray(selected.skills), `${tool} should have skills array`);
-    }
-  });
-
-  describe('getPackageContents(toolId, variant)');
-
-  await testAsync('should return contents with variant filtering for Lite variant', async () => {
-    const contents = await pm.getPackageContents('claude', 'lite');
-
-    assert(contents !== null, 'Contents should not be null');
-    assert(typeof contents === 'object', 'Contents should be an object');
-
-    // Lite variant should have exactly 3 agents
-    assert.strictEqual(contents.agents.length, 3,
-      'Lite variant should have exactly 3 agents');
-
-    // Lite variant should have 0 skills
-    assert.strictEqual(contents.skills.length, 0,
-      'Lite variant should have 0 skills');
-
-    // Should have resources and hooks (all selected with "*")
-    assert(contents.resources.length > 0, 'Should have resources');
-    assert(contents.hooks.length > 0, 'Should have hooks');
-
-    // Should have totalFiles count
-    assert(typeof contents.totalFiles === 'number', 'Should have totalFiles count');
-    assert(contents.totalFiles > 0, 'totalFiles should be greater than 0');
-  });
-
-  await testAsync('should return contents with variant filtering for Standard variant', async () => {
-    const contents = await pm.getPackageContents('claude', 'standard');
-
-    assert(contents !== null, 'Contents should not be null');
-
-    // Standard variant should have all agents (13)
-    assert.strictEqual(contents.agents.length, 13,
-      'Standard variant should have all 13 agents');
-
-    // Standard variant should have exactly 8 skills
-    assert.strictEqual(contents.skills.length, 8,
-      'Standard variant should have exactly 8 skills');
-
-    // Should have resources and hooks
-    assert(contents.resources.length > 0, 'Should have resources');
-    assert(contents.hooks.length > 0, 'Should have hooks');
-
-    // Total files should equal sum of all categories
-    const expectedTotal = contents.agents.length + contents.skills.length +
-                         contents.resources.length + contents.hooks.length;
-    assert.strictEqual(contents.totalFiles, expectedTotal,
-      'totalFiles should equal sum of all content categories');
-  });
-
-  await testAsync('should return contents with variant filtering for Pro variant', async () => {
-    const contents = await pm.getPackageContents('claude', 'pro');
-
-    assert(contents !== null, 'Contents should not be null');
-
-    // Pro variant should have all agents (13)
-    assert.strictEqual(contents.agents.length, 13,
-      'Pro variant should have all 13 agents');
-
-    // Pro variant should have all skills (22)
-    assert.strictEqual(contents.skills.length, 22,
-      'Pro variant should have all 22 skills');
-
-    // Should have all resources and hooks
-    assert(contents.resources.length > 0, 'Should have all resources');
-    assert(contents.hooks.length > 0, 'Should have all hooks');
-  });
-
-  await testAsync('should return file paths in contents arrays', async () => {
-    const contents = await pm.getPackageContents('claude', 'lite');
-
-    // Each array should contain file paths or names
-    assert(Array.isArray(contents.agents), 'agents should be an array');
-    assert(Array.isArray(contents.skills), 'skills should be an array');
-    assert(Array.isArray(contents.resources), 'resources should be an array');
-    assert(Array.isArray(contents.hooks), 'hooks should be an array');
-
-    // Check that agents array contains valid paths/names
-    if (contents.agents.length > 0) {
-      assert(typeof contents.agents[0] === 'string',
-        'Agent entries should be strings');
-    }
-  });
-
-  await testAsync('should throw error for non-existent tool', async () => {
-    try {
-      await pm.getPackageContents('nonexistent-tool', 'lite');
-      throw new Error('Should have thrown error for non-existent tool');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('ENOENT'),
-        'Error should indicate tool not found');
-    }
-  });
-
-  await testAsync('should throw error for invalid variant', async () => {
-    try {
-      await pm.getPackageContents('claude', 'invalid-variant');
-      throw new Error('Should have thrown error for invalid variant');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('invalid'),
-        'Error should indicate invalid variant');
-    }
-  });
-
-  describe('getPackageSize(toolId, variant)');
-
-  await testAsync('should calculate size for Lite variant', async () => {
-    const sizeInfo = await pm.getPackageSize('claude', 'lite');
-
-    assert(sizeInfo !== null, 'Size info should not be null');
-    assert(typeof sizeInfo === 'object', 'Size info should be an object');
-    assert(typeof sizeInfo.size === 'number', 'Should have numeric size');
-    assert(sizeInfo.size >= 0, 'Size should be non-negative');
-    assert(typeof sizeInfo.formattedSize === 'string', 'Should have formatted size');
-  });
-
-  await testAsync('should calculate size for Standard variant', async () => {
-    const sizeInfo = await pm.getPackageSize('claude', 'standard');
-
-    assert(sizeInfo !== null, 'Size info should not be null');
-    assert(typeof sizeInfo.size === 'number', 'Should have numeric size');
-    assert(sizeInfo.size > 0, 'Size should be greater than 0');
-  });
-
-  await testAsync('should calculate size for Pro variant', async () => {
-    const sizeInfo = await pm.getPackageSize('claude', 'pro');
-
-    assert(sizeInfo !== null, 'Size info should not be null');
-    assert(typeof sizeInfo.size === 'number', 'Should have numeric size');
-    assert(sizeInfo.size > 0, 'Size should be greater than 0');
-  });
-
-  await testAsync('should have Pro variant size >= Standard variant size', async () => {
-    const standardSize = await pm.getPackageSize('claude', 'standard');
-    const proSize = await pm.getPackageSize('claude', 'pro');
-
-    assert(proSize.size >= standardSize.size,
-      'Pro variant should have size >= Standard variant (more content)');
-  });
-
-  await testAsync('should have Standard variant size >= Lite variant size', async () => {
-    const liteSize = await pm.getPackageSize('claude', 'lite');
-    const standardSize = await pm.getPackageSize('claude', 'standard');
-
-    assert(standardSize.size >= liteSize.size,
-      'Standard variant should have size >= Lite variant (more content)');
-  });
-
-  await testAsync('should format size correctly (bytes/KB/MB)', async () => {
-    const sizeInfo = await pm.getPackageSize('claude', 'pro');
-
-    assert(typeof sizeInfo.formattedSize === 'string', 'Formatted size should be a string');
-    // Should contain a number followed by a unit (Bytes, KB, MB, GB)
-    const hasValidFormat = /^\d+(\.\d+)?\s+(Bytes|KB|MB|GB)$/.test(sizeInfo.formattedSize);
-    assert(hasValidFormat, `Formatted size should match pattern: ${sizeInfo.formattedSize}`);
-  });
-
-  await testAsync('should calculate size based on variant-filtered content', async () => {
-    // Get contents for verification
-    const liteContents = await pm.getPackageContents('claude', 'lite');
-    const proContents = await pm.getPackageContents('claude', 'pro');
-
-    // Pro has more files, so it should have larger size
-    assert(proContents.totalFiles > liteContents.totalFiles,
-      'Pro should have more files than Lite');
-
-    const liteSize = await pm.getPackageSize('claude', 'lite');
-    const proSize = await pm.getPackageSize('claude', 'pro');
-
-    // Size should correlate with file count
-    assert(proSize.size > liteSize.size,
-      'Pro with more files should have larger size than Lite');
-  });
-
-  await testAsync('should handle skill directories correctly', async () => {
-    // Standard and Pro have skills (directories with multiple files)
-    const standardSize = await pm.getPackageSize('claude', 'standard');
-    const proSize = await pm.getPackageSize('claude', 'pro');
-
-    // Both should have non-zero size
-    assert(standardSize.size > 0, 'Standard with 8 skills should have non-zero size');
-    assert(proSize.size > 0, 'Pro with all skills should have non-zero size');
-
-    // Pro has more skills, so should have larger size
-    assert(proSize.size > standardSize.size,
-      'Pro with all 22 skills should have larger size than Standard with 8 skills');
-  });
-
-  await testAsync('should throw error for non-existent tool', async () => {
-    try {
-      await pm.getPackageSize('nonexistent-tool', 'lite');
-      throw new Error('Should have thrown error for non-existent tool');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('ENOENT'),
-        'Error should indicate tool not found');
-    }
-  });
-
-  await testAsync('should throw error for invalid variant', async () => {
-    try {
-      await pm.getPackageSize('claude', 'invalid-variant');
-      throw new Error('Should have thrown error for invalid variant');
-    } catch (error) {
-      assert(error.message.includes('not found') || error.message.includes('invalid'),
-        'Error should indicate invalid variant');
-    }
-  });
-
-  describe('validatePackage(toolId, variant)');
-
-  await testAsync('should validate a valid package with all required content', async () => {
-    const result = await pm.validatePackage('claude', 'lite');
-
-    assert(result !== null, 'Result should not be null');
-    assert(typeof result === 'object', 'Result should be an object');
-    assert(result.valid === true, 'Package should be valid');
-    assert(Array.isArray(result.issues), 'Should have issues array');
-    assert(result.issues.length === 0, 'Valid package should have no issues');
-  });
-
-  await testAsync('should check variants.json exists', async () => {
-    // Create temp package without variants.json
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-no-variants');
-    const agentsDir = path.join(tempDir, 'agents');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-
-      const result = await pm.validatePackage('test-no-variants', 'lite');
-
-      assert(result.valid === false, 'Package without variants.json should be invalid');
-      assert(result.error && result.error.includes('variants.json') ||
-             result.issues.some(issue => issue.includes('variants.json')),
-        'Error should mention missing variants.json');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate variants.json is valid JSON', async () => {
-    // Create temp package with invalid JSON
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-invalid-variants');
-    const agentsDir = path.join(tempDir, 'agents');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), '{ invalid json }');
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-
-      const result = await pm.validatePackage('test-invalid-variants', 'lite');
-
-      assert(result.valid === false, 'Package with invalid JSON should be invalid');
-      assert(result.error && result.error.includes('JSON') ||
-             result.issues.some(issue => issue.includes('JSON')),
-        'Error should mention invalid JSON');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate all required variants (lite, standard, pro) are present', async () => {
-    // Create temp package with missing variant
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-missing-variant');
-    const agentsDir = path.join(tempDir, 'agents');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      // variants.json missing 'pro' variant
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: { name: 'Lite', description: 'Test', agents: ['master'], skills: [], resources: '*', hooks: '*' },
-        standard: { name: 'Standard', description: 'Test', agents: '*', skills: [], resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-
-      const result = await pm.validatePackage('test-missing-variant', 'lite');
-
-      assert(result.valid === false, 'Package with missing variant should be invalid');
-      assert(result.error && result.error.includes('variant') ||
-             result.issues.some(issue => issue.includes('variant') || issue.includes('pro')),
-        'Error should mention missing variant');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate each variant has required fields', async () => {
-    // Create temp package with incomplete variant definition
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-incomplete-fields');
-    const agentsDir = path.join(tempDir, 'agents');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      // lite variant missing 'description' field
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: { name: 'Lite', agents: ['master'], skills: [], resources: '*', hooks: '*' },  // missing description
-        standard: { name: 'Standard', description: 'Test', agents: '*', skills: [], resources: '*', hooks: '*' },
-        pro: { name: 'Pro', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-
-      const result = await pm.validatePackage('test-incomplete-fields', 'lite');
-
-      assert(result.valid === false, 'Package with incomplete variant should be invalid');
-      assert(result.error && result.error.includes('description') ||
-             result.issues.some(issue => issue.includes('description') || issue.includes('field')),
-        'Error should mention missing field');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate that variant-selected agents exist', async () => {
-    // Create temp package with missing agent
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-missing-agent');
-    const agentsDir = path.join(tempDir, 'agents');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: {
-          name: 'Lite',
-          description: 'Test',
-          agents: ['master', 'nonexistent-agent'],  // nonexistent-agent doesn't exist
-          skills: [],
-          resources: '*',
-          hooks: '*'
-        },
-        standard: { name: 'Standard', description: 'Test', agents: '*', skills: [], resources: '*', hooks: '*' },
-        pro: { name: 'Pro', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-
-      const result = await pm.validatePackage('test-missing-agent', 'lite');
-
-      assert(result.valid === false, 'Package with missing agent should be invalid');
-      assert(result.issues && result.issues.length > 0, 'Should have issues reported');
-      assert(result.issues.some(issue =>
-        issue.includes('nonexistent-agent') || issue.includes('agent') && issue.includes('not found')),
-        'Issues should mention missing agent');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate that variant-selected skills exist', async () => {
-    // Create temp package with missing skill
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-missing-skill');
-    const agentsDir = path.join(tempDir, 'agents');
-    const skillsDir = path.join(tempDir, 'skills');
-    const pdfSkillDir = path.join(skillsDir, 'pdf');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      if (!fs.existsSync(pdfSkillDir)) {
-        fs.mkdirSync(pdfSkillDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: { name: 'Lite', description: 'Test', agents: ['master'], skills: [], resources: '*', hooks: '*' },
-        standard: {
-          name: 'Standard',
-          description: 'Test',
-          agents: '*',
-          skills: ['pdf', 'nonexistent-skill'],  // nonexistent-skill doesn't exist
-          resources: '*',
-          hooks: '*'
-        },
-        pro: { name: 'Pro', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-      fs.writeFileSync(path.join(pdfSkillDir, 'skill.md'), '# PDF Skill');
-
-      const result = await pm.validatePackage('test-missing-skill', 'standard');
-
-      assert(result.valid === false, 'Package with missing skill should be invalid');
-      assert(result.issues && result.issues.length > 0, 'Should have issues reported');
-      assert(result.issues.some(issue =>
-        issue.includes('nonexistent-skill') || issue.includes('skill') && issue.includes('not found')),
-        'Issues should mention missing skill');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(pdfSkillDir, 'skill.md'))) {
-        fs.unlinkSync(path.join(pdfSkillDir, 'skill.md'));
-      }
-      if (fs.existsSync(pdfSkillDir)) {
-        fs.rmdirSync(pdfSkillDir);
-      }
-      if (fs.existsSync(skillsDir)) {
-        fs.rmdirSync(skillsDir);
-      }
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate wildcard selections have directories', async () => {
-    // Create temp package and validate wildcard works
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-wildcard-validation');
-    const agentsDir = path.join(tempDir, 'agents');
-    const skillsDir = path.join(tempDir, 'skills');
-    const pdfSkillDir = path.join(skillsDir, 'pdf');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      if (!fs.existsSync(pdfSkillDir)) {
-        fs.mkdirSync(pdfSkillDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: { name: 'Lite', description: 'Test', agents: ['master'], skills: [], resources: '*', hooks: '*' },
-        standard: { name: 'Standard', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' },
-        pro: { name: 'Pro', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-      fs.writeFileSync(path.join(pdfSkillDir, 'skill.md'), '# PDF Skill');
-
-      const result = await pm.validatePackage('test-wildcard-validation', 'standard');
-
-      assert(result.valid === true, 'Package with valid wildcard should be valid');
-      assert(result.issues.length === 0, 'Valid package should have no issues');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(pdfSkillDir, 'skill.md'))) {
-        fs.unlinkSync(path.join(pdfSkillDir, 'skill.md'));
-      }
-      if (fs.existsSync(pdfSkillDir)) {
-        fs.rmdirSync(pdfSkillDir);
-      }
-      if (fs.existsSync(skillsDir)) {
-        fs.rmdirSync(skillsDir);
-      }
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should validate resources and hooks referenced in variants', async () => {
-    // Create temp package with missing resource
-    const tempDir = path.join(__dirname, '..', '..', 'packages', 'test-missing-resource');
-    const agentsDir = path.join(tempDir, 'agents');
-    const resourcesDir = path.join(tempDir, 'resources');
-
-    try {
-      if (!fs.existsSync(agentsDir)) {
-        fs.mkdirSync(agentsDir, { recursive: true });
-      }
-      if (!fs.existsSync(resourcesDir)) {
-        fs.mkdirSync(resourcesDir, { recursive: true });
-      }
-      fs.writeFileSync(path.join(tempDir, 'variants.json'), JSON.stringify({
-        lite: {
-          name: 'Lite',
-          description: 'Test',
-          agents: ['master'],
-          skills: [],
-          resources: ['config.yaml', 'missing.yaml'],  // missing.yaml doesn't exist
-          hooks: '*'
-        },
-        standard: { name: 'Standard', description: 'Test', agents: '*', skills: [], resources: '*', hooks: '*' },
-        pro: { name: 'Pro', description: 'Test', agents: '*', skills: '*', resources: '*', hooks: '*' }
-      }));
-      fs.writeFileSync(path.join(agentsDir, 'master.md'), '# Test Agent');
-      fs.writeFileSync(path.join(resourcesDir, 'config.yaml'), '# Config');
-
-      const result = await pm.validatePackage('test-missing-resource', 'lite');
-
-      assert(result.valid === false, 'Package with missing resource should be invalid');
-      assert(result.issues && result.issues.length > 0, 'Should have issues reported');
-      assert(result.issues.some(issue =>
-        issue.includes('missing.yaml') || issue.includes('resource') && issue.includes('not found')),
-        'Issues should mention missing resource');
-    } finally {
-      // Cleanup
-      if (fs.existsSync(path.join(resourcesDir, 'config.yaml'))) {
-        fs.unlinkSync(path.join(resourcesDir, 'config.yaml'));
-      }
-      if (fs.existsSync(resourcesDir)) {
-        fs.rmdirSync(resourcesDir);
-      }
-      if (fs.existsSync(path.join(tempDir, 'variants.json'))) {
-        fs.unlinkSync(path.join(tempDir, 'variants.json'));
-      }
-      if (fs.existsSync(path.join(agentsDir, 'master.md'))) {
-        fs.unlinkSync(path.join(agentsDir, 'master.md'));
-      }
-      if (fs.existsSync(agentsDir)) {
-        fs.rmdirSync(agentsDir);
-      }
-      if (fs.existsSync(tempDir)) {
-        fs.rmdirSync(tempDir);
-      }
-    }
-  });
-
-  await testAsync('should return detailed validation results', async () => {
-    const result = await pm.validatePackage('claude', 'standard');
-
-    assert(result !== null, 'Result should not be null');
-    assert(typeof result === 'object', 'Result should be an object');
-    assert(typeof result.valid === 'boolean', 'Should have valid boolean field');
-    assert(Array.isArray(result.issues), 'Should have issues array');
-    assert(typeof result.checkedFiles === 'number' && result.checkedFiles >= 0,
-      'Should have checkedFiles count');
-    assert(typeof result.missingFiles === 'number' && result.missingFiles >= 0,
-      'Should have missingFiles count');
-  });
-
-  // Test summary
-  log('\n=== Test Summary ===', 'blue');
-  log(`Total tests: ${totalTests}`, 'cyan');
-  log(`Passed: ${passedTests}`, 'green');
-  log(`Failed: ${failedTests}`, failedTests > 0 ? 'red' : 'green');
-
-  if (failedTests === 0) {
-    log('\nAll tests passed!', 'green');
-  } else {
-    log('\nSome tests failed!', 'red');
-    process.exit(1);
-  }
+  pm.packagesDir = packagesDir;
+  return pm;
 }
 
-// Run tests
-runTests().catch(error => {
-  log(`\nFatal error: ${error.message}`, 'red');
-  console.error(error);
+async function writeVariantsJson(root, toolId, obj) {
+  const toolDir = path.join(root, toolId);
+  await fs.promises.mkdir(toolDir, { recursive: true });
+  await fs.promises.writeFile(path.join(toolDir, 'variants.json'), JSON.stringify(obj, null, 2));
+  return toolDir;
+}
+
+async function main() {
+  console.log(`${colors.bright}${colors.cyan}installer/package-manager.js${colors.reset}\n`);
+
+  // ---- loadVariantConfig -------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const config = await pm.loadVariantConfig('claude');
+    check('loadVariantConfig: real claude variants.json has exactly one variant, pro',
+      Object.keys(config).length === 1 && !!config.pro,
+      `keys: ${JSON.stringify(Object.keys(config))}`);
+    check('loadVariantConfig: pro carries the required fields',
+      typeof config.pro.name === 'string' && typeof config.pro.description === 'string' && !!config.pro.agents,
+      JSON.stringify(config.pro));
+  }
+
+  await checkThrows('loadVariantConfig: throws for a tool with no packages/<id> dir',
+    () => new PackageManager().loadVariantConfig('not-a-real-tool'),
+    (msg) => /Variants file not found/.test(msg));
+
+  await withFixture(async (root) => {
+    const pm = pmOverPackagesDir(root);
+    await fs.promises.mkdir(path.join(root, 'ghost'), { recursive: true });
+    await checkThrows('loadVariantConfig: throws when variants.json itself is missing',
+      () => pm.loadVariantConfig('ghost'),
+      (msg) => /Variants file not found/.test(msg));
+  });
+
+  await withFixture(async (root) => {
+    const toolDir = path.join(root, 'badjson');
+    await fs.promises.mkdir(toolDir, { recursive: true });
+    await fs.promises.writeFile(path.join(toolDir, 'variants.json'), '{ this is not json');
+    const pm = pmOverPackagesDir(root);
+    await checkThrows('loadVariantConfig: throws with a clear message for malformed JSON',
+      () => pm.loadVariantConfig('badjson'),
+      (msg) => /Invalid JSON in variants\.json for tool badjson/.test(msg));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 'novariant', { notpro: { name: 'X', description: 'Y', agents: '*' } });
+    const pm = pmOverPackagesDir(root);
+    await checkThrows("loadVariantConfig: throws when the required 'pro' variant is absent",
+      () => pm.loadVariantConfig('novariant'),
+      (msg) => /Required variant 'pro' not found/.test(msg));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 'missingfield', { pro: { name: 'Pro', description: 'desc' /* no agents */ } });
+    const pm = pmOverPackagesDir(root);
+    await checkThrows("loadVariantConfig: throws when a required field ('agents') is missing from pro",
+      () => pm.loadVariantConfig('missingfield'),
+      (msg) => /Required field 'agents' missing/.test(msg));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 'cached', { pro: { name: 'Before', description: 'd', agents: '*' } });
+    const pm = pmOverPackagesDir(root);
+    const first = await pm.loadVariantConfig('cached');
+    // Mutate on disk after the first load; a cache hit must not see this.
+    await writeVariantsJson(root, 'cached', { pro: { name: 'After', description: 'd', agents: '*' } });
+    const second = await pm.loadVariantConfig('cached');
+    check('loadVariantConfig: caches per toolId (a later on-disk edit is not re-read)',
+      first.pro.name === 'Before' && second.pro.name === 'Before',
+      `first=${first.pro.name}, second=${second.pro.name}`);
+  });
+
+  // ---- getVariantMetadata -------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const meta = await pm.getVariantMetadata('claude', 'pro');
+    check("getVariantMetadata: real claude 'pro' has name 'Pro'", meta.name === 'Pro', meta.name);
+  }
+
+  await checkThrows("getVariantMetadata: throws for 'lite', which no longer exists",
+    () => new PackageManager().getVariantMetadata('claude', 'lite'),
+    (msg) => /Variant 'lite' not found for tool claude/.test(msg));
+
+  await checkThrows("getVariantMetadata: throws for 'standard', which no longer exists",
+    () => new PackageManager().getVariantMetadata('claude', 'standard'),
+    (msg) => /Variant 'standard' not found for tool claude/.test(msg));
+
+  // ---- selectVariantContent -----------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const available = await pm.getAvailableContent(REAL_PACKAGES_DIR + '/claude');
+    const selected = await pm.selectVariantContent('claude', 'pro', available);
+    check("selectVariantContent: wildcard '*' selects every available agent",
+      selected.agents.length === available.agents.length &&
+        available.agents.every((a) => selected.agents.includes(a)),
+      `available=${available.agents.length}, selected=${selected.agents.length}`);
+  }
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: ['keep'] } });
+    const pm = pmOverPackagesDir(root);
+    const selected = await pm.selectVariantContent('t', 'pro', { agents: ['keep', 'drop'] });
+    check('selectVariantContent: an explicit array selects only the named items',
+      selected.agents.length === 1 && selected.agents[0] === 'keep',
+      JSON.stringify(selected.agents));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: ['ghost'] } });
+    const pm = pmOverPackagesDir(root);
+    await checkThrows('selectVariantContent: an item that does not exist in availableContent throws',
+      () => pm.selectVariantContent('t', 'pro', { agents: [] }),
+      (msg) => /Item 'ghost' specified in pro variant agents not found/.test(msg));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: '*', commands: ['gone', 'stay'] } });
+    const pm = pmOverPackagesDir(root);
+    const selected = await pm.selectVariantContent('t', 'pro', { agents: [], commands: ['stay'] });
+    check('selectVariantContent: commands silently skip missing items (skipMissing=true)',
+      selected.commands.length === 1 && selected.commands[0] === 'stay',
+      JSON.stringify(selected.commands));
+  });
+
+  await withFixture(async (root) => {
+    await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: [] } });
+    const pm = pmOverPackagesDir(root);
+    const selected = await pm.selectVariantContent('t', 'pro', { agents: ['a', 'b'] });
+    check('selectVariantContent: an empty array selection yields no items',
+      Array.isArray(selected.agents) && selected.agents.length === 0,
+      JSON.stringify(selected.agents));
+  });
+
+  // ---- getAvailableVariants ------------------------------------------------
+  // NOTE: this method checks for a subdirectory literally named after the
+  // variant (packages/<tool>/<variant>/) — a layout left over from a
+  // pre-single-variant installer. No such subdirectory exists anywhere in
+  // packages/ today (see the bug reported at the end of this file), so this
+  // is exercised against a fixture that reproduces the historical shape it
+  // still assumes. Deliberately NOT asserted against real packages/: pinning
+  // the current [] result would bake the bug's own output in as expected, so
+  // fixing the bug would read as a regression.
+
+  await withFixture(async (root) => {
+    const toolDir = await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: '*' } });
+    await fs.promises.mkdir(path.join(toolDir, 'pro'), { recursive: true });
+    const pm = pmOverPackagesDir(root);
+    check("getAvailableVariants: lists 'pro' when packages/<tool>/pro/ exists",
+      JSON.stringify(pm.getAvailableVariants('t')) === JSON.stringify(['pro']),
+      JSON.stringify(pm.getAvailableVariants('t')));
+  });
+
+  // ---- getAvailableContent: dynamic directory-name resolution --------------
+  // (Not the dedup behaviour — that suite owns this method's dedup contract.)
+
+  {
+    const pm = new PackageManager();
+    const droid = await pm.getAvailableContent(path.join(REAL_PACKAGES_DIR, 'droid'));
+    check("getAvailableContent: resolves droid's agents directory as 'droids'",
+      droid.agentsDir === 'droids' && droid.agents.length > 0,
+      `agentsDir=${droid.agentsDir}, count=${droid.agents.length}`);
+
+    const opencode = await pm.getAvailableContent(path.join(REAL_PACKAGES_DIR, 'opencode'));
+    check("getAvailableContent: resolves opencode's agents/commands dirs as singular 'agent'/'command'",
+      opencode.agentsDir === 'agent' && opencode.commandsDir === 'command' &&
+        opencode.agents.length > 0 && opencode.commands.length > 0,
+      `agentsDir=${opencode.agentsDir}, commandsDir=${opencode.commandsDir}`);
+  }
+
+  // ---- getPackageContents --------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const contents = await pm.getPackageContents('claude', 'pro');
+    const sum = contents.agents.length + contents.skills.length + contents.commands.length +
+      contents.resources.length + contents.hooks.length + contents.plugins.length;
+    check('getPackageContents: real claude/pro resolves a non-empty set of agents and skills',
+      contents.agents.length > 0 && contents.skills.length > 0,
+      `agents=${contents.agents.length}, skills=${contents.skills.length}`);
+    check('getPackageContents: totalFiles equals the sum of every category',
+      contents.totalFiles === sum,
+      `totalFiles=${contents.totalFiles}, sum=${sum}`);
+  }
+
+  await checkThrows('getPackageContents: throws for an unknown tool',
+    () => new PackageManager().getPackageContents('not-a-real-tool', 'pro'),
+    (msg) => /Package not found: not-a-real-tool/.test(msg));
+
+  await checkThrows("getPackageContents: throws for an unknown variant ('standard') on a real tool",
+    () => new PackageManager().getPackageContents('claude', 'standard'),
+    (msg) => /Variant 'standard' not found for tool claude/.test(msg));
+
+  // ---- countFiles -----------------------------------------------------------
+
+  await withFixture(async (root) => {
+    await fs.promises.mkdir(path.join(root, 'nested', 'deeper'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'a');
+    await fs.promises.writeFile(path.join(root, 'nested', 'b.txt'), 'b');
+    await fs.promises.writeFile(path.join(root, 'nested', 'deeper', 'c.txt'), 'c');
+    const pm = new PackageManager();
+    const files = await pm.countFiles(root);
+    check('countFiles: recurses into nested directories and counts only files',
+      files.length === 3 && files.every((f) => f.endsWith('.txt')),
+      JSON.stringify(files));
+  });
+
+  // ---- formatBytes -----------------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    check("formatBytes(0) === '0 Bytes'", pm.formatBytes(0) === '0 Bytes', pm.formatBytes(0));
+    check("formatBytes(1024) === '1 KB'", pm.formatBytes(1024) === '1 KB', pm.formatBytes(1024));
+    check("formatBytes(1536) === '1.5 KB'", pm.formatBytes(1536) === '1.5 KB', pm.formatBytes(1536));
+    check("formatBytes(1048576) === '1 MB'", pm.formatBytes(1048576) === '1 MB', pm.formatBytes(1048576));
+  }
+
+  // ---- getPackageSize ---------------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const { size, formattedSize } = await pm.getPackageSize('claude', 'pro');
+    check('getPackageSize: real claude/pro has a positive total size', size > 0, size);
+    check("getPackageSize: formattedSize matches formatBytes(size)",
+      formattedSize === pm.formatBytes(size), `${formattedSize} vs ${pm.formatBytes(size)}`);
+  }
+
+  // ---- validatePackage ---------------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    const result = await pm.validatePackage('claude', 'pro');
+    check('validatePackage: real claude/pro is valid with zero issues',
+      result.valid === true && result.issues.length === 0,
+      JSON.stringify(result));
+  }
+
+  await withFixture(async (root) => {
+    // A variant that selects an agent no available agent provides. Since
+    // getAvailableContent only ever lists names that exist on disk,
+    // selectVariantContent's own existence check rejects 'ghost' before
+    // validatePackage's per-item file check ever runs — the result is still
+    // an invalid package, just reported via the catch-and-report path (see
+    // Check 6 in validatePackage) rather than the missingFiles counter.
+    const toolDir = await writeVariantsJson(root, 't', { pro: { name: 'P', description: 'd', agents: ['ghost'] } });
+    await fs.promises.mkdir(path.join(toolDir, 'agents'), { recursive: true });
+    // Note: nothing named ghost.md is written, so 'ghost' never appears in
+    // availableContent either.
+    const pm = pmOverPackagesDir(root);
+    const result = await pm.validatePackage('t', 'pro');
+    check('validatePackage: reports an unresolvable selected agent as invalid',
+      result.valid === false && /ghost/.test(result.error),
+      JSON.stringify(result));
+  });
+
+  {
+    // validatePackage never throws for a bad variant name — it catches the
+    // error from selectVariantContent and returns an invalid result instead.
+    const pm = new PackageManager();
+    const result = await pm.validatePackage('claude', 'standard');
+    check("validatePackage: reports (never throws) invalid for an unknown variant ('standard')",
+      result.valid === false && /Variant 'standard' not found for tool claude/.test(result.error),
+      JSON.stringify(result));
+  }
+
+  {
+    const pm = new PackageManager();
+    const result = await pm.validatePackage('not-a-real-tool', 'pro');
+    check('validatePackage: reports a missing package directory as invalid rather than throwing',
+      result.valid === false && /Package directory not found/.test(result.error),
+      JSON.stringify(result));
+  }
+
+  // ---- getManifestTemplate ---------------------------------------------------------
+
+  {
+    const pm = new PackageManager();
+    for (const tool of ['claude', 'ampcode', 'droid', 'opencode']) {
+      const template = pm.getManifestTemplate(tool);
+      check(`getManifestTemplate: real ${tool} template parses with its own 'tool' field intact`,
+        template && template.tool === tool,
+        JSON.stringify(template));
+
+      // There is one install: everything. installation-engine.generateManifest
+      // spreads this template wholesale into the manifest.json written to the
+      // user's machine, so any field here ships to disk — and a
+      // `supported_variants` list would advertise a choice that does not exist
+      // and that nothing reads.
+      check(`getManifestTemplate: ${tool} advertises no variant choice`,
+        template && !('supported_variants' in template),
+        JSON.stringify(template && template.supported_variants));
+    }
+  }
+
+  await checkThrows('getManifestTemplate: throws for a tool with no manifest template',
+    () => new PackageManager().getManifestTemplate('not-a-real-tool'),
+    (msg) => /Manifest template not found for tool: not-a-real-tool/.test(msg));
+}
+
+main().then(() => {
+  // Summary format is a contract with tests/run-all-tests.js, which parses
+  // /Total tests:\s+(\d+)/, /Passed:\s+(\d+)/ and /Failed:\s+(\d+)/. Emit
+  // anything else and the runner reads 0 tests and fails the count floor.
+  console.log(`\n${colors.bright}${'='.repeat(60)}${colors.reset}`);
+  console.log(`Total tests: ${passed + failed}`);
+  console.log(`${colors.green}Passed: ${passed}${colors.reset}`);
+  console.log(`${colors.red}Failed: ${failed}${colors.reset}`);
+  if (failed) {
+    console.log(`\n${colors.red}Failures:${colors.reset}`);
+    for (const f of failures) console.log(`  - ${f.name}${f.detail ? `: ${f.detail}` : ''}`);
+  }
+  process.exit(failed ? 1 : 0);
+}).catch((err) => {
+  console.error(`${colors.red}Suite crashed:${colors.reset} ${err && err.stack || err}`);
+  console.log(`\nTotal tests: ${passed + failed}`);
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed + 1}`);
   process.exit(1);
 });

--- a/tests/mirror/mirror.test.js
+++ b/tests/mirror/mirror.test.js
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+
+/**
+ * mirror.cjs behavioural tests — frontmatter freeze and orphan detection.
+ *
+ * Why this file exists: mirror.cjs's `shapes` subcommand used to derive
+ * required/optional frontmatter keys from the files' own content and `check`
+ * judged those same files against it, so dropping a key from EVERY file of a
+ * kit and re-running `shapes` made the key silently stop being required — a
+ * circular check. And `check` only ever walked packages/claude (sources()),
+ * so a capability removed there left a stale copy behind in droid/opencode/
+ * ampcode that nothing ever reported (a hand cleanup of 33 files in a
+ * downstream mirror). scripts/frontmatter.json now freezes a shape that
+ * `shapes` refuses to overwrite without --force, and `check` walks every
+ * kit's own dirs looking for files with no matching packages/claude source.
+ * These tests prove both: a weakened shape is refused and named, and an
+ * orphaned file is reported no matter where it hides.
+ *
+ * Conventions follow tests/sync-rules/sync-rules.test.js: self-contained,
+ * ephemeral tmpdirs, negative controls so the suite can prove it can FAIL.
+ *
+ * mirror.cjs resolves ROOT as path.resolve(__dirname, '..'), so every test
+ * builds a miniature fake repo in a tmpdir (its own scripts/mirror.cjs,
+ * scripts/frontmatter.json, packages/*) rather than touching this repo's
+ * real packages/ tree — sync writes files, and check/shapes must never be
+ * pointed at the real ROOT during a test run.
+ *
+ * Set MIRROR_SCRIPT to point at a different mirror.cjs (used to run this same
+ * suite against the pre-freeze/pre-orphan commit as a failing-first proof).
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = process.env.MIRROR_SCRIPT
+  || path.join(__dirname, '..', '..', 'scripts', 'mirror.cjs');
+
+const tmpDirs = [];
+function tmpDir(prefix) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+process.on('exit', () => {
+  if (process.env.KEEP_TMP) return;
+  for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+});
+
+const colors = { reset: '\x1b[0m', green: '\x1b[32m', red: '\x1b[31m',
+  yellow: '\x1b[33m', cyan: '\x1b[36m', bright: '\x1b[1m' };
+
+let passed = 0, failed = 0;
+const failures = [];
+function check(name, cond, detail) {
+  if (cond) { passed++; console.log(`  ${colors.green}PASS${colors.reset} ${name}`); }
+  else {
+    failed++; failures.push({ name, detail });
+    console.log(`  ${colors.red}FAIL${colors.reset} ${name}`);
+    if (detail) console.log(`       ${colors.yellow}${detail}${colors.reset}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake-repo builders
+// ---------------------------------------------------------------------------
+
+function writeFile(p, content) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+function copyRecursive(src, dest) {
+  const st = fs.lstatSync(src);
+  if (st.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) copyRecursive(path.join(src, entry), path.join(dest, entry));
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+const fm = (lines) => `---\n${lines.join('\n')}\n---\n`;
+
+/** The 8 dirs mirror.cjs's DIRS map expects to exist (empty is fine). */
+function emptyKitDirs(repo) {
+  for (const d of [
+    'packages/claude/agents', 'packages/claude/skills',
+    'packages/droid/droids', 'packages/droid/commands',
+    'packages/ampcode/agents', 'packages/ampcode/skills',
+    'packages/opencode/agent', 'packages/opencode/command',
+  ]) fs.mkdirSync(path.join(repo, d), { recursive: true });
+}
+
+/** A fresh fake repo with mirror.cjs copied in and the 8 shape dirs present. */
+function newRepo(prefix) {
+  const repo = tmpDir(prefix);
+  writeFile(path.join(repo, 'scripts', 'mirror.cjs'), fs.readFileSync(SCRIPT));
+  emptyKitDirs(repo);
+  return repo;
+}
+
+function run(repo, mode, extraArgs = []) {
+  const r = spawnSync(process.execPath,
+    [path.join(repo, 'scripts', 'mirror.cjs'), mode, ...extraArgs],
+    { encoding: 'utf8', timeout: 20000 });
+  return { status: r.status, stdout: (r.stdout || ''), stderr: (r.stderr || '') };
+}
+
+/**
+ * A fully self-consistent mirrored repo: one agent (foo) and one skill (bar,
+ * with a bundled helper.cjs) present in all four kits, bodies matching after
+ * substitution, frontmatter satisfying each kit's own shape, and a
+ * frontmatter.json frozen to match — `check` should report nothing at all.
+ */
+function buildCleanRepo(prefix) {
+  const repo = newRepo(prefix);
+  const P = (...p) => path.join(repo, ...p);
+
+  writeFile(P('packages/claude/agents/foo.md'),
+    fm(['name: foo', 'description: Foo agent', 'model: sonnet', 'color: blue',
+      'when_to_use: Use for foo things']) + 'Foo body text.\n');
+  writeFile(P('packages/claude/skills/bar/SKILL.md'),
+    fm(['name: bar', 'description: Bar skill', 'allowed-tools: Bash(git diff:*)']) + 'Bar body text.\n');
+  const helperSrc = "// helper script\nconsole.log('hi');\n";
+  writeFile(P('packages/claude/skills/bar/helper.cjs'), helperSrc);
+
+  writeFile(P('packages/droid/droids/foo.md'),
+    fm(['name: foo', 'description: Foo agent', 'model: sonnet', 'tools: Read, Write']) + 'Foo body text.\n');
+  writeFile(P('packages/droid/commands/bar.md'),
+    fm(['description: Bar skill']) + 'Bar body text.\n');
+  writeFile(P('packages/droid/commands/bar/helper.cjs'), helperSrc);
+
+  writeFile(P('packages/ampcode/agents/foo.md'),
+    fm(['name: foo', 'description: Foo agent', 'model: sonnet', 'color: blue',
+      'when_to_use: Use for foo things']) + 'Foo body text.\n');
+  writeFile(P('packages/ampcode/skills/bar/SKILL.md'),
+    fm(['name: bar', 'description: Bar skill', 'allowed-tools: Bash(git diff:*)']) + 'Bar body text.\n');
+  writeFile(P('packages/ampcode/skills/bar/helper.cjs'), helperSrc);
+
+  writeFile(P('packages/opencode/agent/foo.md'),
+    fm(['name: foo', 'description: Foo agent', 'mode: subagent', 'temperature: 0.2',
+      'tools: read, write', 'when_to_use: Use for foo things']) + 'Foo body text.\n');
+  writeFile(P('packages/opencode/command/bar.md'),
+    fm(['description: Bar skill']) + 'Bar body text.\n');
+  writeFile(P('packages/opencode/command/bar/helper.cjs'), helperSrc);
+
+  const shape = {
+    frozen: '2026-01-01',
+    subagent: {
+      claude: { required: ['color', 'description', 'model', 'name', 'when_to_use'], optional: [], bashStyle: null },
+      droid: { required: ['description', 'model', 'name', 'tools'], optional: [], bashStyle: null },
+      ampcode: { required: ['color', 'description', 'model', 'name', 'when_to_use'], optional: [], bashStyle: null },
+      opencode: { required: ['description', 'mode', 'name', 'temperature', 'tools', 'when_to_use'], optional: [], bashStyle: null },
+    },
+    command: {
+      droid: { required: ['description'], optional: [], bashStyle: null },
+      opencode: { required: ['description'], optional: [], bashStyle: null },
+    },
+    skill: {
+      claude: { required: ['allowed-tools', 'description', 'name'], optional: [], bashStyle: 'colon' },
+      ampcode: { required: ['allowed-tools', 'description', 'name'], optional: [], bashStyle: 'colon' },
+    },
+  };
+  writeFile(P('scripts/frontmatter.json'), `${JSON.stringify(shape, null, 2)}\n`);
+  return repo;
+}
+
+const orphanLines = (stderr) => stderr.split('\n').filter((l) => l.startsWith('ORPHAN'));
+
+console.log(`\n${colors.bright}${colors.cyan}mirror.cjs${colors.reset}`);
+console.log(`${colors.cyan}(against ${path.relative(process.cwd(), SCRIPT)})${colors.reset}\n`);
+
+// ===========================================================================
+// FREEZE (`shapes` subcommand)
+// ===========================================================================
+
+// 1. no existing frontmatter.json -> shapes writes one, with a frozen date.
+{
+  const repo = newRepo('mir-boot-');
+  const shapeFile = path.join(repo, 'scripts', 'frontmatter.json');
+  const r = run(repo, 'shapes');
+  check('bootstrap: shapes exits 0', r.status === 0, `status=${r.status} stderr=${r.stderr}`);
+  const parsed = fs.existsSync(shapeFile) ? JSON.parse(fs.readFileSync(shapeFile, 'utf8')) : null;
+  check('bootstrap: frontmatter.json is created and carries a frozen date',
+    !!parsed && /^\d{4}-\d{2}-\d{2}$/.test(parsed.frozen),
+    `parsed=${JSON.stringify(parsed)}`);
+  check('bootstrap: stdout says it wrote the file', /wrote/.test(r.stdout), `stdout=${JSON.stringify(r.stdout)}`);
+}
+
+// A shared repo for tests 2-6: two agent files (foo, baz) with an identical
+// key set, so removing a key from BOTH is a shape-wide weakening.
+const AGENT_KEYS = ['name: %s', 'description: %s agent', 'model: sonnet', 'color: blue', 'when_to_use: Use for %s things'];
+function writeAgentPair(repo, keys) {
+  for (const name of ['foo', 'baz']) {
+    writeFile(path.join(repo, 'packages/claude/agents', `${name}.md`),
+      fm(keys.map((k) => k.replace(/%s/g, name))) + `${name} body.\n`);
+  }
+}
+
+const weakenRepo = newRepo('mir-weaken-');
+writeAgentPair(weakenRepo, AGENT_KEYS);
+const shapeFile = path.join(weakenRepo, 'scripts', 'frontmatter.json');
+run(weakenRepo, 'shapes'); // establish the baseline frozen shape (includes when_to_use)
+const baseline = fs.readFileSync(shapeFile);
+
+// 2. computed shape matches frozen -> exit 0, no rewrite.
+{
+  const before = fs.statSync(shapeFile).mtimeMs;
+  const beforeBytes = fs.readFileSync(shapeFile);
+  const r = run(weakenRepo, 'shapes');
+  const after = fs.statSync(shapeFile).mtimeMs;
+  check('matches frozen: exits 0', r.status === 0, `status=${r.status} stderr=${r.stderr}`);
+  check('matches frozen: file is not rewritten',
+    before === after && beforeBytes.equals(fs.readFileSync(shapeFile)),
+    `before=${before} after=${after}`);
+  check('matches frozen: says there is nothing to do',
+    /nothing to do/.test(r.stdout), `stdout=${JSON.stringify(r.stdout)}`);
+}
+
+// Now remove the required key from EVERY file of the kit.
+writeAgentPair(weakenRepo, AGENT_KEYS.slice(0, 4)); // drops when_to_use from both
+
+// 3. shapes refuses to silently demote a key that vanished from every file.
+{
+  const r = run(weakenRepo, 'shapes');
+  check('weakening: shapes exits non-zero', r.status !== 0, `status=${r.status}`);
+  check('weakening: frontmatter.json is NOT rewritten',
+    fs.readFileSync(shapeFile).equals(baseline),
+    `unchanged=${fs.readFileSync(shapeFile).equals(baseline)}`);
+  check('weakening: stderr names the key and calls it WEAKENING',
+    /WEAKENING/.test(r.stderr) && /when_to_use/.test(r.stderr),
+    `stderr=${JSON.stringify(r.stderr)}`);
+}
+
+// 5. `check` (not shapes) independently catches the same regression, because
+//    the frozen file — not today's files — is the judge.
+{
+  const r = run(weakenRepo, 'check');
+  check('check: exits non-zero on a required key missing from every file', r.status !== 0, `status=${r.status}`);
+  check("check: stderr reports the missing required key 'when_to_use'",
+    /missing required key 'when_to_use'/.test(r.stderr), `stderr=${JSON.stringify(r.stderr)}`);
+}
+
+// 4. --force deliberately re-records the weaker shape.
+{
+  const r = run(weakenRepo, 'shapes', ['--force']);
+  check('force: exits 0', r.status === 0, `status=${r.status} stderr=${r.stderr}`);
+  const rewritten = fs.readFileSync(shapeFile);
+  check('force: frontmatter.json IS rewritten', !rewritten.equals(baseline));
+  const parsed = JSON.parse(rewritten.toString('utf8'));
+  check('force: new shape stamps a frozen date and drops the vanished key from required',
+    /^\d{4}-\d{2}-\d{2}$/.test(parsed.frozen) && !parsed.subagent.claude.required.includes('when_to_use'),
+    `parsed=${JSON.stringify(parsed.subagent.claude)}`);
+}
+
+// 6. negative control: an ADDED key present in only ONE of the two files is a
+//    plain change (optional key added), never WEAKENING.
+{
+  const postForce = fs.readFileSync(shapeFile);
+  writeFile(path.join(weakenRepo, 'packages/claude/agents/foo.md'),
+    fm(['name: foo', 'description: foo agent', 'model: sonnet', 'color: blue', 'extra_key: yes']) + 'foo body.\n');
+  const r = run(weakenRepo, 'shapes');
+  check('added optional key: shapes still refuses without --force (a diff exists)',
+    r.status !== 0, `status=${r.status}`);
+  check('added optional key: frontmatter.json is NOT rewritten',
+    fs.readFileSync(shapeFile).equals(postForce));
+  const addedLine = r.stderr.split('\n').find((l) => l.includes("'extra_key' added to optional"));
+  check('added optional key: reported as a plain change, not WEAKENING',
+    !!addedLine && !addedLine.startsWith('WEAKENING'),
+    `line=${JSON.stringify(addedLine)}`);
+}
+
+// ===========================================================================
+// ORPHANS (`check` subcommand)
+// ===========================================================================
+
+// 7. a clean, fully-mirrored repo reports no orphans and exits 0.
+{
+  const repo = buildCleanRepo('mir-clean-');
+  const r = run(repo, 'check');
+  check('clean repo: check exits 0', r.status === 0, `status=${r.status} stderr=${r.stderr}`);
+  check('clean repo: no ORPHAN lines at all', orphanLines(r.stderr).length === 0, r.stderr);
+}
+
+// 8-11: a repo with three planted orphans of different shapes, plus the
+// clean repo's own legitimate bundled files, in one run — proving each stray
+// is caught and no legitimate file is ever mistaken for one.
+{
+  const repo = buildCleanRepo('mir-orphans-');
+  // 8. a stray top-level command file with no packages/claude source at all.
+  writeFile(path.join(repo, 'packages/droid/commands/zzz-orphan.md'), 'stray, no source\n');
+  // 9. a stray file living inside an otherwise-legitimate bundled asset dir —
+  //    the shape that hid 33 real files in a downstream mirror.
+  writeFile(path.join(repo, 'packages/droid/commands/bar/zzz-stale.cjs'), '// stale leftover\n');
+  // 10. a whole orphaned skill directory in ampcode.
+  writeFile(path.join(repo, 'packages/ampcode/skills/zzz-dead/SKILL.md'), fm(['name: zzz-dead', 'description: dead', 'allowed-tools: Read']) + 'dead\n');
+
+  const r = run(repo, 'check');
+  const orphans = orphanLines(r.stderr);
+  check('planted orphans: check exits non-zero', r.status !== 0, `status=${r.status}`);
+  check('stray top-level file: reported as ORPHAN',
+    orphans.some((l) => l.includes('zzz-orphan.md')), r.stderr);
+  check('stray file inside a legitimate bundled dir: reported as ORPHAN',
+    orphans.some((l) => l.includes(path.join('bar', 'zzz-stale.cjs'))), r.stderr);
+  check('orphaned skill directory: reported as ORPHAN',
+    orphans.some((l) => l.includes(path.join('zzz-dead', 'SKILL.md'))), r.stderr);
+  check('negative control: the legitimate sibling helper.cjs is NOT reported',
+    !orphans.some((l) => l.includes(path.join('bar', 'helper.cjs'))), r.stderr);
+  check('negative control: none of the genuinely mirrored files (foo.md, bar.md) are reported',
+    !orphans.some((l) => /(^|\/)foo\.md:/.test(l) || /(^|\/)bar\.md:/.test(l)), r.stderr);
+}
+
+// 12. negative control: an EXEMPT entry's target file is still expected to
+//     exist and must never be reported as an orphan (EXEMPT excuses body
+//     checking only, per mirror.cjs's own checkOrphans comment).
+{
+  const repo = buildCleanRepo('mir-exempt-');
+  // 'agent:orchestrator.md' is hardcoded EXEMPT in mirror.cjs.
+  writeFile(path.join(repo, 'packages/claude/agents/orchestrator.md'),
+    fm(['name: orchestrator', 'description: Orchestrator', 'model: sonnet', 'color: blue', 'when_to_use: Route work']) + 'claude-only body.\n');
+  writeFile(path.join(repo, 'packages/droid/droids/orchestrator.md'),
+    fm(['name: orchestrator', 'description: Orchestrator', 'model: sonnet', 'tools: Read']) + 'droid-only body, deliberately different.\n');
+  writeFile(path.join(repo, 'packages/ampcode/agents/orchestrator.md'),
+    fm(['name: orchestrator', 'description: Orchestrator', 'model: sonnet', 'color: blue', 'when_to_use: Route work']) + 'ampcode-only body, deliberately different.\n');
+  writeFile(path.join(repo, 'packages/opencode/agent/orchestrator.md'),
+    fm(['name: orchestrator', 'description: Orchestrator', 'mode: subagent', 'temperature: 0.2', 'tools: read', 'when_to_use: Route work']) + 'opencode-only body, deliberately different.\n');
+
+  const r = run(repo, 'check');
+  const orphans = orphanLines(r.stderr);
+  check('exempt entry: its target files across all kits are NOT reported as orphans',
+    !orphans.some((l) => l.includes('orchestrator.md')), r.stderr);
+  check('exempt entry: overall check still exits 0 (bodies differ but are excused)',
+    r.status === 0, `status=${r.status} stderr=${r.stderr}`);
+}
+
+console.log(`\n${colors.bright}${'='.repeat(60)}${colors.reset}`);
+console.log(`Total tests: ${passed + failed}`);
+console.log(`${colors.green}Passed: ${passed}${colors.reset}`);
+console.log(`${colors.red}Failed: ${failed}${colors.reset}`);
+if (failed) {
+  console.log(`\n${colors.red}Failures:${colors.reset}`);
+  for (const f of failures) console.log(`  - ${f.name}${f.detail ? `: ${f.detail}` : ''}`);
+}
+process.exit(failed ? 1 : 0);

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -94,6 +94,12 @@ const testSuites = [
     file: 'installer/closing-note.test.js',
     description: 'Tests installer/cli.js formatBackupClosingNote: silent on a fresh install, ~-substituted backup paths, and never hardcodes the claude-only commands/remember path',
     expectedTests: 7
+  },
+  {
+    name: 'package-manager dedup',
+    file: 'installer/package-manager-dedup.test.js',
+    description: 'Tests installer/package-manager.js getAvailableContent lists a capability shipping both <name>.md and a same-named <name>/ once, across commands/, the singular command/, agents/ and skills/, without collapsing distinct names',
+    expectedTests: 7
   }
 ];
 

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -27,8 +27,7 @@ const colors = {
 
 // Test suite definitions. These reflect the single-variant installer (one
 // 'pro' package per tool). The legacy Variant and Path Handling suites were
-// removed with the 3-variant system; other tests/installer/*.test.js files
-// are not wired in here.
+// removed with the 3-variant system.
 const testSuites = [
   {
     name: 'Multi-Tool Installation',
@@ -100,6 +99,12 @@ const testSuites = [
     file: 'installer/package-manager-dedup.test.js',
     description: 'Tests installer/package-manager.js getAvailableContent lists a capability shipping both <name>.md and a same-named <name>/ once, across commands/, the singular command/, agents/ and skills/, without collapsing distinct names',
     expectedTests: 7
+  },
+  {
+    name: 'package-manager',
+    file: 'installer/package-manager.test.js',
+    description: 'Tests installer/package-manager.js against the single-variant (pro) reality: loadVariantConfig validation and caching, selectVariantContent wildcard/array/skipMissing selection, getPackageContents/getPackageSize/validatePackage/getManifestTemplate against real package data, and countFiles/formatBytes',
+    expectedTests: 43
   }
 ];
 

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -78,6 +78,12 @@ const testSuites = [
     expectedTests: 25
   },
   {
+    name: 'mirror',
+    file: 'mirror/mirror.test.js',
+    description: 'Tests mirror.cjs frontmatter-shape freeze (refuses a weakened shape without --force) and orphan detection (a stray file with no packages/claude source, anywhere in a kit tree) against isolated fake repos',
+    expectedTests: 27
+  },
+  {
     name: 'stub-check',
     file: 'stub-check/stub-check.test.js',
     description: 'Tests stub-check.cjs repairs the MEMORY include and demotes the pre-v2.19 AGENT_RULES @-include, editing only inside the markers and never repointing at a missing file',

--- a/tools/ampcode/manifest-template.json
+++ b/tools/ampcode/manifest-template.json
@@ -6,7 +6,6 @@
   "optimization": "amplified-codegen",
   "integration_type": "cli",
   "manifest_format": "ampcode-config",
-  "supported_variants": ["lite", "standard", "pro"],
   "agent_format": "amplified-optimized",
   "skill_compatibility": "ampcode-native",
   "resource_format": "enhanced",

--- a/tools/claude/manifest-template.json
+++ b/tools/claude/manifest-template.json
@@ -6,7 +6,6 @@
   "optimization": "conversational-ai",
   "integration_type": "plugin",
   "manifest_format": "claude-plugin",
-  "supported_variants": ["lite", "standard", "pro"],
   "agent_format": "claude-conversational",
   "skill_compatibility": "claude-native",
   "resource_format": "markdown",

--- a/tools/droid/manifest-template.json
+++ b/tools/droid/manifest-template.json
@@ -6,7 +6,6 @@
   "optimization": "mobile-codegen",
   "integration_type": "cli",
   "manifest_format": "droid-config",
-  "supported_variants": ["lite", "standard", "pro"],
   "agent_format": "mobile-optimized",
   "skill_compatibility": "droid-native",
   "resource_format": "mobile-focused",

--- a/tools/opencode/manifest-template.json
+++ b/tools/opencode/manifest-template.json
@@ -6,7 +6,6 @@
   "optimization": "cli-codegen",
   "integration_type": "cli",
   "manifest_format": "opencode-config",
-  "supported_variants": ["lite", "standard", "pro"],
   "agent_format": "cli-optimized",
   "skill_compatibility": "cli-native",
   "resource_format": "terminal",


### PR DESCRIPTION
## What's in it

**Added**
- `scripts/frontmatter.json` is frozen and date-stamped. `mirror.cjs shapes` refuses to overwrite a recorded shape with a weaker one and reports `WEAKENING`; `--force` re-records deliberately.
- `mirror.cjs check` detects orphaned kit files — anything under a mirrored tool directory with no source under `packages/claude`.
- `/branch-review`'s review-record guard. A recorded `last-review.md` is now validated before it is trusted: its `sha:` must resolve to a real commit and be an ancestor of HEAD, and its `branch:` must match the current branch. A record left by a merged, renamed, or rebased branch is treated as no record and falls through to a full review. Previously only `sha:` was compared, so a stale record resolved to a commit range that never existed.

**Fixed**
- `supported_variants` removed from all four `tools/*/manifest-template.json`. It advertised `["lite","standard","pro"]` in every installed `manifest.json` when only one install exists, and nothing read the field.
- `tests/installer/package-manager.test.js` had never been registered in `tests/run-all-tests.js`, so it had never run — 22 of its 44 tests failed against the removed three-variant installer, and 11 fixtures were written into `packages/` inside the repo. Rewritten against the single-variant reality, every fixture now in an isolated temp directory, and registered.

**Changed**
- Installer test coverage 1103 → 1153. `getAvailableContent`'s deduplication now has a regression suite of its own.

## Verification
- `npm test` → exit 0, 1153 passed, 0 failed
- `node scripts/mirror.cjs check` → exit 0, 99 bodies in sync across 3 kits
- `/branch-review` at `3d7c2a5`: verdict ready, all three stages ran, no blockers, fix ledger empty
- New suites proven falsifiable by mutation, not by assertion: wildcard `*` → `[]`, `formatBytes` k=1000, `countFiles` non-recursive, and `getVariantMetadata` name-drop each redden the tests that claim to cover them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QodDFbdJpH1v2AAaV2LLZU